### PR TITLE
Stop printing banner in compact mode

### DIFF
--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -46,7 +46,7 @@ pretty = Config "  " "\n" " " True True True
 -- | Configuration to print to a compacted unreadable CSS output.
 
 compact :: Config
-compact = Config "" "" "" False False True
+compact = Config "" "" "" False False False
 
 -- | Render to CSS using the default configuration (`pretty`) and directly
 -- print to the standard output.


### PR DESCRIPTION
The goal of compact mode is to shave as many bytes as possible
while printing CSS that is semantically the same.

Any comments are counter-productive to this goal.
