### PR TITLE
fixed key for whiteSpace

### DIFF
--- a/src/Clay/Text.hs
+++ b/src/Clay/Text.hs
@@ -169,7 +169,7 @@ newtype WhiteSpace = WhiteSpace Value
   deriving (Val, Normal, Inherit, Other)
 
 whiteSpace :: WhiteSpace -> Css
-whiteSpace = key "whiteSpace"
+whiteSpace = key "white-space"
 
 pre, nowrap, preWrap, preLine :: WhiteSpace
 


### PR DESCRIPTION
I think this must have been a typo while implementing the key for the white-space attribute. The patch should be self-explanatory.
