### PR TITLE
Add missing HTML5 elements

### DIFF
--- a/src/Clay/Elements.hs
+++ b/src/Clay/Elements.hs
@@ -26,11 +26,11 @@ a, address, area, article, aside, audio, b, base, bdi, bdo, blockquote,
   body, br, button, canvas, caption, code, col, colgroup, datalist, dd, del,
   details, dfn, dialog, div, dl, dt, em, embed, fieldset, figcaption, figure,
   footer, h1, h2, h3, h4, h5, h6, head, header, hgroup, hr, html, i, iframe,
-  img, input, ins, kbd, keygen, legend, li, link, map, mark, menu, meta, meter,
-  nav, noscript, object, ol, optgroup, option, output, p, param, pre, progress,
-  q, rp, rt, ruby, s, samp, script, section, select, small, source, strong,
-  sub, summary, sup, table, tbody, td, textarea, tfoot, th, thead, time, tr,
-  track, u, ul, var, video, wbr :: Selector
+  img, input, ins, kbd, keygen, legend, li, link, main_, map, mark, math, menu,
+  meta, meter, nav, noscript, object, ol, optgroup, option, output, p, param,
+  pre, progress, q, rp, rt, ruby, s, samp, script, section, select, small,
+  source, strong, sub, summary, sup, svg, table, tbody, td, template, textarea,
+  tfoot, th, thead, time, tr, track, u, ul, var, video, wbr :: Selector
 
 a = "a"
 address = "address"
@@ -87,11 +87,13 @@ keygen = "keygen"
 legend = "legend"
 li = "li"
 link = "link"
+main_ = "main"
 map = "map"
 mark = "mark"
 menu = "menu"
 meta = "meta"
 meter = "meter"
+math = "math"
 nav = "nav"
 noscript = "noscript"
 object = "object"
@@ -118,9 +120,11 @@ strong = "strong"
 sub = "sub"
 summary = "summary"
 sup = "sup"
+svg = "svg"
 table = "table"
 tbody = "tbody"
 td = "td"
+template = "template"
 textarea = "textarea"
 tfoot = "tfoot"
 th = "th"


### PR DESCRIPTION
Namely, add the `main`, `math`, `svg`, and `template` elements. The `main` element has been named `main_` to avoid namespace collisions.
