### PR TITLE
Add several CSS 3 selectors and pseudo-classes

### DIFF
--- a/src/Clay.hs
+++ b/src/Clay.hs
@@ -45,7 +45,9 @@ module Clay
 
 , attr
 , (@=)
+, (^=)
 , ($=)
+, (*=)
 , (~=)
 , (|=)
 
@@ -115,7 +117,7 @@ import Clay.Stylesheet
 import Clay.Selector
 import Clay.Property
 
-import Clay.Pseudo
+import Clay.Pseudo hiding (default_, required, root, lang)
 import Clay.Elements hiding (link, em)
 import Clay.Attributes hiding
   ( content, class_, target, checked, disabled

--- a/src/Clay/Pseudo.hs
+++ b/src/Clay/Pseudo.hs
@@ -23,19 +23,33 @@ focus      = ":focus"
 firstChild = ":first-child"
 lastChild  = ":last-child"
 
-firstOfType, lastOfType, empty, target, checked, enabled, disabled :: Refinement
+checked, default_, disabled, empty, enabled, firstOfType, indeterminate,
+  inRange, invalid, lastOfType, onlyChild, onlyOfType, optional,
+  outOfRange, required, root, target, valid :: Refinement
 
-firstOfType = ":first-of-type"
-lastOfType  = ":last-of-type"
-empty       = ":empty"
-target      = ":target"
-checked     = ":checked"
-enabled     = ":enabled"
-disabled    = ":disabled"
+checked       = ":checked"
+default_      = ":default"
+disabled      = ":disabled"
+empty         = ":empty"
+enabled       = ":enabled"
+firstOfType   = ":first-of-type"
+indeterminate = ":indeterminate"
+inRange       = ":in-range"
+invalid       = ":invalid"
+lastOfType    = ":last-of-type"
+onlyChild     = ":only-child"
+onlyOfType    = ":only-of-type"
+optional      = ":optional"
+outOfRange    = ":out-of-range"
+required      = ":required"
+root          = ":root"
+target        = ":target"
+valid         = ":valid"
 
-nthChild, nthLastChild, nthOfType :: Text -> Refinement
+lang, nthChild, nthLastChild, nthLastOfType, nthOfType :: Text -> Refinement
 
-nthChild     n = func "nth-child"      [n]
-nthLastChild n = func "nth-last-child" [n]
-nthOfType    n = func "nth-of-type"    [n]
-
+lang          n = func "lang"             [n]
+nthChild      n = func "nth-child"        [n]
+nthLastChild  n = func "nth-last-child"   [n]
+nthLastOfType n = func "nth-last-of-type" [n]
+nthOfType     n = func "nth-of-type"      [n]

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -245,14 +245,16 @@ selector cfg = intersperse ("," <> newline cfg) . rec
 predicate :: Predicate -> Builder
 predicate ft = mconcat $
   case ft of
-    Id         a   -> [ "#", fromText a                                             ]
-    Class      a   -> [ ".", fromText a                                             ]
-    Attr       a   -> [ "[", fromText a,                     "]"                    ]
-    AttrVal    a v -> [ "[", fromText a,  "='", fromText v, "']"                    ]
-    AttrEnds   a v -> [ "[", fromText a, "$='", fromText v, "']"                    ]
-    AttrSpace  a v -> [ "[", fromText a, "~='", fromText v, "']"                    ]
-    AttrHyph   a v -> [ "[", fromText a, "|='", fromText v, "']"                    ]
-    Pseudo     a   -> [ ":", fromText a                                             ]
-    PseudoFunc a p -> [ ":", fromText a, "(", intersperse "," (map fromText p), ")" ]
+    Id           a   -> [ "#", fromText a                                             ]
+    Class        a   -> [ ".", fromText a                                             ]
+    Attr         a   -> [ "[", fromText a,                     "]"                    ]
+    AttrVal      a v -> [ "[", fromText a,  "='", fromText v, "']"                    ]
+    AttrBegins   a v -> [ "[", fromText a, "^='", fromText v, "']"                    ]
+    AttrEnds     a v -> [ "[", fromText a, "$='", fromText v, "']"                    ]
+    AttrContains a v -> [ "[", fromText a, "*='", fromText v, "']"                    ]
+    AttrSpace    a v -> [ "[", fromText a, "~='", fromText v, "']"                    ]
+    AttrHyph     a v -> [ "[", fromText a, "|='", fromText v, "']"                    ]
+    Pseudo       a   -> [ ":", fromText a                                             ]
+    PseudoFunc   a p -> [ ":", fromText a, "(", intersperse "," (map fromText p), ")" ]
 
 

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -102,11 +102,23 @@ attr = Refinement . pure . Attr
 (@=) :: Text -> Text -> Refinement
 (@=) a = Refinement . pure . AttrVal a
 
+-- | Filter elements based on the presence of a certain attribute that begins
+-- with the selected value.
+
+(^=) :: Text -> Text -> Refinement
+(^=) a = Refinement . pure . AttrBegins a
+
 -- | Filter elements based on the presence of a certain attribute that ends
 -- with the specified value.
 
 ($=) :: Text -> Text -> Refinement
 ($=) a = Refinement . pure . AttrEnds a
+
+-- | Filter elements based on the presence of a certain attribute that contains
+-- the specified value as a substring.
+
+(*=) :: Text -> Text -> Refinement
+(*=) a = Refinement . pure . AttrContains a
 
 -- | Filter elements based on the presence of a certain attribute that have the
 -- specified value contained in a space separated list.
@@ -123,15 +135,17 @@ attr = Refinement . pure . Attr
 -------------------------------------------------------------------------------
 
 data Predicate
-  = Id         Text
-  | Class      Text
-  | Attr       Text
-  | AttrVal    Text Text
-  | AttrEnds   Text Text
-  | AttrSpace  Text Text
-  | AttrHyph   Text Text
-  | Pseudo     Text
-  | PseudoFunc Text [Text]
+  = Id           Text
+  | Class        Text
+  | Attr         Text
+  | AttrVal      Text Text
+  | AttrBegins   Text Text
+  | AttrEnds     Text Text
+  | AttrContains Text Text
+  | AttrSpace    Text Text
+  | AttrHyph     Text Text
+  | Pseudo       Text
+  | PseudoFunc   Text [Text]
   deriving (Eq, Ord, Show)
 
 newtype Refinement = Refinement { unFilter :: [Predicate] }


### PR DESCRIPTION
- Add selectors `^=` and `*=`.
- Add pseudo-classes `:default`, `:indeterminate`, `:invalid`,
  `:lang()`, `:in-range`, `:nth-last-of-type()`, `:only-child`,
  `:only-of-type`, `:optional`, `:out-of-range`, `:required`,
  `:root`, and `:valid`.
