### PR TITLE
add support for importing css from urls

### DIFF
--- a/src/Clay.hs
+++ b/src/Clay.hs
@@ -67,6 +67,10 @@ module Clay
 
 , fontFace
 
+-- * Import other CSS files
+
+, importUrl
+
 -- * Pseudo elements and classes.
 
 , module Clay.Pseudo

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -164,6 +164,7 @@ rules :: Config -> [App] -> [Rule] -> Builder
 rules cfg sel rs = mconcat
   [ rule cfg sel (mapMaybe property rs)
   , newline cfg
+  ,             imp    cfg              `foldMap` mapMaybe imports rs
   ,             kframe cfg              `foldMap` mapMaybe kframes rs
   ,             face   cfg              `foldMap` mapMaybe faces   rs
   , (\(a, b) -> rules  cfg (a : sel) b) `foldMap` mapMaybe nested  rs
@@ -179,6 +180,17 @@ rules cfg sel rs = mconcat
         kframes  _              = Nothing
         faces    (Face ns     ) = Just ns
         faces    _              = Nothing
+        imports  (Import i    ) = Just i
+        imports  _              = Nothing
+
+imp :: Config -> Text -> Builder
+imp cfg t =
+  mconcat
+    [ "@import url("
+    , fromText t
+    , ");"
+    , newline cfg ]
+
 
 rule :: Config -> [App] -> [(Key (), Value)] -> Builder
 rule _   _   []    = mempty

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -43,6 +43,7 @@ data Rule
   | Query    MediaQuery [Rule]
   | Face     [Rule]
   | Keyframe Keyframes
+  | Import   Text
   deriving Show
 
 newtype StyleM a = S (Writer [Rule] a)
@@ -148,4 +149,10 @@ keyframesFromTo n a b = keyframes n [(0, a), (100, b)]
 
 fontFace :: Css -> Css
 fontFace rs = rule $ Face (runS rs)
+
+
+-- | Import a CSS file from a URL
+
+importUrl :: Text -> Css
+importUrl l = rule $ Import l
 


### PR DESCRIPTION
this patch adds support for css `@import` statements. as far as i can see, clay doesn't have these at the moment (or at least doesn't have an obvious function for doing it)