### PR TITLE
hacky support for `border-collapse` #88

### DIFF
--- a/src/Clay/Border.hs
+++ b/src/Clay/Border.hs
@@ -25,6 +25,9 @@ module Clay.Border
 , borderRadius
 , borderTopLeftRadius, borderTopRightRadius
 , borderBottomLeftRadius, borderBottomRightRadius
+
+-- * Collapsing borders model for a table
+, borderCollapse
 )
 where
 
@@ -33,6 +36,7 @@ import Clay.Stylesheet
 import Clay.Color
 import Clay.Common
 import Clay.Size
+import Clay.Display
 
 newtype Stroke = Stroke Value
   deriving (Val, Other, Inherit, Auto, None)
@@ -151,3 +155,19 @@ borderTopRightRadius    a b = key "border-top-right-radius"    (a ! b)
 borderBottomLeftRadius  a b = key "border-bottom-left-radius"  (a ! b)
 borderBottomRightRadius a b = key "border-bottom-right-radius" (a ! b)
 
+-------------------------------------------------------------------------------
+
+{- newtype Collapse = Collapse Value
+  deriving (Val, Initial, Inherit, Other)
+
+collapseCollapse, collapseSeparate :: Collapse
+
+collapseCollapse = Collapse "collapse"
+collapseSeparate  = Collapse "separate" -}
+
+{-  Due conflict with Visibility collapse
+    Preferred just to add separate to Visibility
+    Because (borderCollapse collapseCollapse) sounds bad -}
+
+borderCollapse :: Visibility -> Css
+borderCollapse = key "border-collapse"

--- a/src/Clay/Display.hs
+++ b/src/Clay/Display.hs
@@ -37,7 +37,8 @@ module Clay.Display
 -- * Visibility.
 
 , Visibility
-, collapse
+, collapse, separate
+
 , visibility
 
 -- Clipping.
@@ -179,8 +180,10 @@ overflowY = key "overflow-y"
 newtype Visibility = Visibility Value
   deriving (Val, Other, Auto, Inherit, Hidden, Visible)
 
-collapse :: Visibility
+separate, collapse :: Visibility
+
 collapse = Visibility "collapse"
+separate = Visibility "separate"
 
 visibility :: Visibility -> Css
 visibility = key "visibility"


### PR DESCRIPTION
collapse conflicts with `Visibility` `collapse`

there are two bad ways: call `collapse` another word or add separate to `Visibility` and use it there

Since I can't imagine another intuitive name for collapse there is implementation with `borderCollapse :: Visibility -> Css`