### PR TITLE
Add boxShadowWithSpread function to Clay.Box to allow for spread radius.

### DIFF
--- a/src/Clay/Box.hs
+++ b/src/Clay/Box.hs
@@ -39,6 +39,10 @@ boxSizing = prefixed (browsers <> "box-sizing")
 boxShadow :: Size a -> Size a -> Size a -> Color -> Css
 boxShadow x y w c = prefixed (browsers <> "box-shadow") (x ! y ! w ! c)
 
+boxShadowWithSpread :: Size a -> Size a -> Size a -> Size a -> Color -> Css
+boxShadowWithSpread x y blurRadius spreadRadius color =
+    prefixed (browsers <> "box-shadow") (x ! y ! blurRadius ! spreadRadius ! color)
+
 boxShadows :: [(Size a, Size a, Size a, Color)] -> Css
 boxShadows = prefixed (browsers <> "box-shadow") . map (\(a, b, c, d) -> a ! b ! c ! d)
 


### PR DESCRIPTION
Unless I'm missing something, there is currently no option for adding the spread radius to a box shadow. This should do it.