### PR TITLE
Handle pseudo elements correctly

### DIFF
--- a/src/Clay/Pseudo.hs
+++ b/src/Clay/Pseudo.hs
@@ -8,11 +8,18 @@ import Clay.Selector
 -- List of specific pseudo classes, from:
 -- https://developer.mozilla.org/en-US/docs/CSS/Pseudo-classes
 
-after, before :: Refinement
+-- * Pseudo elements
 
-after  = ":after"
-before = ":before"
+after, before, firstLetter, firstLine, selection, backdrop :: Refinement
 
+after       = "::after"
+before      = "::before"
+firstLetter = "::first-letter"
+firstLine   = "::first-line"
+selection   = "::selection"
+backdrop    = "::backdrop"
+
+-- * Pseudo classes
 link, visited, active, hover, focus, firstChild, lastChild :: Refinement
 
 link       = ":link"

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -11,26 +11,26 @@ module Clay.Render
 )
 where
 
-import Control.Applicative
-import Control.Monad.Writer
-import Data.Either
-import Data.Foldable (foldMap)
-import Data.List (sort,sortBy)
-import Data.Maybe
-import Data.Text (Text, pack)
-import Data.Text.Lazy.Builder
-import Prelude hiding ((**))
+import           Control.Applicative
+import           Control.Monad.Writer
+import           Data.Either
+import           Data.Foldable          (foldMap)
+import           Data.List              (sort, sortBy)
+import           Data.Maybe
+import           Data.Text              (Text, pack)
+import           Data.Text.Lazy.Builder
+import           Prelude                hiding ((**))
 
-import qualified Data.Text         as Text
-import qualified Data.Text.Lazy    as Lazy
-import qualified Data.Text.Lazy.IO as Lazy
+import qualified Data.Text              as Text
+import qualified Data.Text.Lazy         as Lazy
+import qualified Data.Text.Lazy.IO      as Lazy
 
-import Clay.Stylesheet hiding (Child, query, rule)
-import Clay.Common (browsers)
-import Clay.Property
-import Clay.Selector
+import           Clay.Common            (browsers)
+import           Clay.Property
+import           Clay.Selector
+import           Clay.Stylesheet        hiding (Child, query, rule)
 
-import qualified Clay.Stylesheet as Rule
+import qualified Clay.Stylesheet        as Rule
 
 
 data Config = Config
@@ -249,11 +249,10 @@ properties cfg xs =
                       then fromText (Text.replicate (width - Text.length k) " ")
                       else ""
              in mconcat [ind, fromText k, pad, ":", sep cfg, fromText v]
-                
+
 selector :: Config -> Selector -> Builder
 selector cfg = intersperse ("," <> newline cfg) . rec
-  where
-    rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
+  where rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
           case p of
             Star           -> if null ft then ["*"] else [""]
             Elem t         -> [fromText t]

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -15,7 +15,7 @@ import Control.Applicative
 import Control.Monad.Writer
 import Data.Either
 import Data.Foldable (foldMap)
-import Data.List (sort)
+import Data.List (sort,sortBy)
 import Data.Maybe
 import Data.Text (Text, pack)
 import Data.Text.Lazy.Builder
@@ -251,7 +251,10 @@ properties cfg xs =
 
 selector :: Config -> Selector -> Builder
 selector cfg = intersperse ("," <> newline cfg) . rec
-  where rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
+  where
+    cmp' (Pseudo _) (Pseudo _) = EQ
+    cmp' a b = compare a b
+    rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sortBy cmp' ft)) <$>
           case p of
             Star           -> if null ft then ["*"] else [""]
             Elem t         -> [fromText t]

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -32,6 +32,7 @@ import Clay.Selector
 
 import qualified Clay.Stylesheet as Rule
 
+
 data Config = Config
   { indentation    :: Builder
   , newline        :: Builder
@@ -248,13 +249,11 @@ properties cfg xs =
                       then fromText (Text.replicate (width - Text.length k) " ")
                       else ""
              in mconcat [ind, fromText k, pad, ":", sep cfg, fromText v]
-
+                
 selector :: Config -> Selector -> Builder
 selector cfg = intersperse ("," <> newline cfg) . rec
   where
-    cmp' (Pseudo _) (Pseudo _) = EQ
-    cmp' a b = compare a b
-    rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sortBy cmp' ft)) <$>
+    rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
           case p of
             Star           -> if null ft then ["*"] else [""]
             Elem t         -> [fromText t]
@@ -267,16 +266,16 @@ selector cfg = intersperse ("," <> newline cfg) . rec
 predicate :: Predicate -> Builder
 predicate ft = mconcat $
   case ft of
-    Id           a   -> [ "#", fromText a                                             ]
-    Class        a   -> [ ".", fromText a                                             ]
-    Attr         a   -> [ "[", fromText a,                     "]"                    ]
-    AttrVal      a v -> [ "[", fromText a,  "='", fromText v, "']"                    ]
-    AttrBegins   a v -> [ "[", fromText a, "^='", fromText v, "']"                    ]
-    AttrEnds     a v -> [ "[", fromText a, "$='", fromText v, "']"                    ]
-    AttrContains a v -> [ "[", fromText a, "*='", fromText v, "']"                    ]
-    AttrSpace    a v -> [ "[", fromText a, "~='", fromText v, "']"                    ]
-    AttrHyph     a v -> [ "[", fromText a, "|='", fromText v, "']"                    ]
-    Pseudo       a   -> [ ":", fromText a                                             ]
-    PseudoFunc   a p -> [ ":", fromText a, "(", intersperse "," (map fromText p), ")" ]
-
+    Id           a   -> [ "#" , fromText a                                             ]
+    Class        a   -> [ "." , fromText a                                             ]
+    Attr         a   -> [ "[" , fromText a,                     "]"                    ]
+    AttrVal      a v -> [ "[" , fromText a,  "='", fromText v, "']"                    ]
+    AttrBegins   a v -> [ "[" , fromText a, "^='", fromText v, "']"                    ]
+    AttrEnds     a v -> [ "[" , fromText a, "$='", fromText v, "']"                    ]
+    AttrContains a v -> [ "[" , fromText a, "*='", fromText v, "']"                    ]
+    AttrSpace    a v -> [ "[" , fromText a, "~='", fromText v, "']"                    ]
+    AttrHyph     a v -> [ "[" , fromText a, "|='", fromText v, "']"                    ]
+    Pseudo       a   -> [ ":" , fromText a                                             ]
+    PseudoFunc   a p -> [ ":" , fromText a, "(", intersperse "," (map fromText p), ")" ]
+    PseudoElem   a   -> [ "::", fromText a                                             ]
 

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -161,9 +161,10 @@ filterFromText t = Refinement $
   case Text.uncons t of
     Just ('#', s) -> [Id     s]
     Just ('.', s) -> [Class  s]
-    Just (':', Text.uncons -> Just (':',s))
-                  -> [PseudoElem s]
-    Just (':', s) -> [Pseudo s]
+    Just (':', s)
+      | Just (':',s') <- Text.uncons s
+                  -> [PseudoElem s']
+      | otherwise -> [Pseudo s]
     Just ('@', s) -> [Attr   s]
     _             -> [Attr   t]
 

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -5,6 +5,7 @@
   , GeneralizedNewtypeDeriving
   , StandaloneDeriving
   , UndecidableInstances
+  , ViewPatterns
   #-}
 module Clay.Selector where
 
@@ -146,6 +147,7 @@ data Predicate
   | AttrHyph     Text Text
   | Pseudo       Text
   | PseudoFunc   Text [Text]
+  | PseudoElem   Text
   deriving (Eq, Ord, Show)
 
 newtype Refinement = Refinement { unFilter :: [Predicate] }
@@ -159,6 +161,8 @@ filterFromText t = Refinement $
   case Text.uncons t of
     Just ('#', s) -> [Id     s]
     Just ('.', s) -> [Class  s]
+    Just (':', Text.uncons -> Just (':',s))
+                  -> [PseudoElem s]
     Just (':', s) -> [Pseudo s]
     Just ('@', s) -> [Attr   s]
     _             -> [Attr   t]


### PR DESCRIPTION
According to the [CSS3 standard](https://www.w3.org/TR/css3-selectors/#pseudo-elements), 
"Only one pseudo-element may appear per selector, and if present it must appear after the sequence of simple selectors that represents the subjects of the selector. "

But clay does not handle pseudo elements correctly.
for example:
```{.haskell}
TL.putStr . renderWith pretty [] $ (hover & (after & (C.width $ pct 100)))
```
result:
```
:after:hover
{
  width : 100%;
}
```
this code is not appropreate because `:after` appears at the first of the selector.

With this fix, clay generates the following code.
```{.css}
:hover::after
{
  width : 100%;
}
```

If there is some problem in this patch, let me know.