### PR TITLE
Clean up units and percentages

### DIFF
--- a/src/Clay/Border.hs
+++ b/src/Clay/Border.hs
@@ -56,7 +56,7 @@ outset = Stroke "outset"
 
 -------------------------------------------------------------------------------
 
-border, borderTop, borderLeft, borderBottom, borderRight :: Stroke -> Size Abs -> Color -> Css
+border, borderTop, borderLeft, borderBottom, borderRight :: Stroke -> Size LengthUnit -> Color -> Css
 
 border        a b c = key "border"        (a ! b ! c)
 borderTop     a b c = key "border-top"    (a ! b ! c)
@@ -86,10 +86,10 @@ borderRightStyle  = key "border-right-style"
 borderTopStyle    = key "border-top-style"
 borderBottomStyle = key "border-bottom-style"
 
-borderWidth4 :: Size Abs -> Size Abs -> Size Abs -> Size Abs -> Css
+borderWidth4 :: Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Css
 borderWidth4 a b c d = key "border-width" (a ! b ! c ! d)
 
-borderWidth, borderLeftWidth, borderRightWidth, borderTopWidth, borderBottomWidth :: Size Abs -> Css
+borderWidth, borderLeftWidth, borderRightWidth, borderTopWidth, borderBottomWidth :: Size LengthUnit -> Css
 
 borderWidth       = key "border-width"
 borderLeftWidth   = key "border-left-width"
@@ -99,7 +99,7 @@ borderBottomWidth = key "border-bottom-width"
 
 -------------------------------------------------------------------------------
 
-outline, outlineTop, outlineLeft, outlineBottom, outlineRight :: Stroke -> Size Abs -> Color -> Css
+outline, outlineTop, outlineLeft, outlineBottom, outlineRight :: Stroke -> Size LengthUnit -> Color -> Css
 
 outline        a b c = key "outline"        (a ! b ! c)
 outlineTop     a b c = key "outline-top"    (a ! b ! c)
@@ -129,10 +129,10 @@ outlineRightStyle  = key "outline-right-style"
 outlineTopStyle    = key "outline-top-style"
 outlineBottomStyle = key "outline-bottom-style"
 
-outlineWidth4 :: Size Abs -> Size Abs -> Size Abs -> Size Abs -> Css
+outlineWidth4 :: Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Css
 outlineWidth4 a b c d = key "outline-width" (a ! b ! c ! d)
 
-outlineWidth, outlineLeftWidth, outlineRightWidth, outlineTopWidth, outlineBottomWidth :: Size Abs -> Css
+outlineWidth, outlineLeftWidth, outlineRightWidth, outlineTopWidth, outlineBottomWidth :: Size LengthUnit -> Css
 
 outlineWidth       = key "outline-width"
 outlineLeftWidth   = key "outline-left-width"
@@ -140,7 +140,7 @@ outlineRightWidth  = key "outline-right-width"
 outlineTopWidth    = key "outline-top-width"
 outlineBottomWidth = key "outline-bottom-width"
 
-outlineOffset :: Size Abs -> Css
+outlineOffset :: Size LengthUnit -> Css
 outlineOffset = key "outline-offset"
 
 -------------------------------------------------------------------------------

--- a/src/Clay/Filter.hs
+++ b/src/Clay/Filter.hs
@@ -49,7 +49,7 @@ filters x = prefixed (browsers <> "filter") (noCommas x)
 url :: Text -> Filter
 url u = Filter ("url(" <> value u <> ")")
 
-blur :: Size Abs -> Filter
+blur :: Size LengthUnit -> Filter
 blur i = Filter ("blur(" <> value i <> ")")
 
 brightness :: Double -> Filter
@@ -58,7 +58,7 @@ brightness i = Filter ("brightness(" <> value i <> ")")
 contrast :: Size Percentage -> Filter
 contrast i = Filter ("contrast(" <> value i <> ")")
 
-dropShadow :: Size Abs -> Size Abs -> Size Abs -> Color -> Filter
+dropShadow :: Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Color -> Filter
 dropShadow x y s c = Filter ("drop-shadow(" <> value (x ! y ! s ! c) <> ")")
 
 grayscale :: Size Percentage -> Filter

--- a/src/Clay/Filter.hs
+++ b/src/Clay/Filter.hs
@@ -55,27 +55,27 @@ blur i = Filter ("blur(" <> value i <> ")")
 brightness :: Double -> Filter
 brightness i = Filter ("brightness(" <> value i <> ")")
 
-contrast :: Size Rel -> Filter
+contrast :: Size Percentage -> Filter
 contrast i = Filter ("contrast(" <> value i <> ")")
 
 dropShadow :: Size Abs -> Size Abs -> Size Abs -> Color -> Filter
 dropShadow x y s c = Filter ("drop-shadow(" <> value (x ! y ! s ! c) <> ")")
 
-grayscale :: Size Rel -> Filter
+grayscale :: Size Percentage -> Filter
 grayscale g = Filter ("grayscale(" <> value g <> ")")
 
 hueRotate :: Angle a -> Filter
 hueRotate h = Filter ("hue-rotate(" <> value h <> ")")
 
-invert :: Size Rel -> Filter
+invert :: Size Percentage -> Filter
 invert i = Filter ("invert(" <> value i <> ")")
 
-opacity :: Size Rel -> Filter
+opacity :: Size Percentage -> Filter
 opacity i = Filter ("opacity(" <> value i <> ")")
 
-saturate :: Size Rel -> Filter
+saturate :: Size Percentage -> Filter
 saturate i = Filter ("saturate(" <> value i <> ")")
 
-sepia :: Size Rel -> Filter
+sepia :: Size Percentage -> Filter
 sepia i = Filter ("sepia(" <> value i <> ")")
 

--- a/src/Clay/Gradient.hs
+++ b/src/Clay/Gradient.hs
@@ -44,7 +44,7 @@ import Clay.Property
 import Clay.Size
 import Clay.Background
 
-type Ramp = [(Color, Size Rel)]
+type Ramp = [(Color, Size Percentage)]
 
 -------------------------------------------------------------------------------
 
@@ -115,5 +115,5 @@ ramp :: Ramp -> Value
 ramp xs = value (map (\(a, b) -> value (value a, value b)) xs)
 
 shortcut :: (Ramp -> BackgroundImage) -> Color -> Color -> BackgroundImage
-shortcut g f t = g [(f, 0), (t, 100)]
+shortcut g f t = g [(f, (pct 0)), (t, (pct 100))]
 

--- a/src/Clay/Gradient.hs
+++ b/src/Clay/Gradient.hs
@@ -81,7 +81,7 @@ circle ext = Radial ("circle " <> value ext)
 ellipse :: Extend -> Radial
 ellipse ext = Radial ("ellipse " <> value ext)
 
-circular :: Size Abs -> Radial
+circular :: Size LengthUnit -> Radial
 circular radius = Radial (value (radius, radius))
 
 elliptical :: Size a -> Size a -> Radial

--- a/src/Clay/Media.hs
+++ b/src/Clay/Media.hs
@@ -72,7 +72,7 @@ without f = Feature f Nothing
 
 width, minWidth, maxWidth, height, minHeight, maxHeight, deviceWidth
   , minDeviceWidth, maxDeviceWidth, deviceHeight, minDeviceHeight
-  , maxDeviceHeight :: Size Abs -> Feature
+  , maxDeviceHeight :: Size LengthUnit -> Feature
 
 width           = with "width"
 minWidth        = with "min-width"

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -11,6 +11,7 @@ module Clay.Size
   Size
 , Abs
 , Rel
+, Percentage
 , nil
 , unitless
 
@@ -64,11 +65,14 @@ import Clay.Stylesheet
 
 -------------------------------------------------------------------------------
 
--- | Sizes can be relative like percentages or rems.
+-- | Sizes can be relative like ems or rems.
 data Rel
 
 -- | Sizes can be absolute like pixels, points, etc.
 data Abs
+
+-- | Sizes can be given in percentages
+data Percentage
 
 newtype Size a = Size Value
   deriving (Val, Auto, Normal, Inherit, None, Other)
@@ -101,7 +105,8 @@ pt i = Size (value i <> "pt")
 -- | Size in picas (1pc = 12pt).
 pc i = Size (value i <> "pc")
 
-em, ex, pct, rem, vw, vh, vmin, vmax :: Double -> Size Rel
+pct :: Double -> Size Percentage
+em, ex, rem, vw, vh, vmin, vmax :: Double -> Size Rel
 
 -- | Size in em's (computed value of the font-size).
 em i = Size (value i <> "em")
@@ -139,7 +144,7 @@ instance Fractional (Size Abs) where
   fromRational = px . fromRational
   recip  = error  "recip not implemented for Size"
 
-instance Num (Size Rel) where
+instance Num (Size Percentage) where
   fromInteger = pct . fromInteger
   (+)    = error   "plus not implemented for Size"
   (*)    = error  "times not implemented for Size"
@@ -147,7 +152,7 @@ instance Num (Size Rel) where
   signum = error "signum not implemented for Size"
   negate = error "negate not implemented for Size"
 
-instance Fractional (Size Rel) where
+instance Fractional (Size Percentage) where
   fromRational = pct . fromRational
   recip  = error  "recip not implemented for Size"
 

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -9,8 +9,7 @@ module Clay.Size
 
 -- * Size type.
   Size
-, Abs
-, Rel
+, LengthUnit
 , Percentage
 , nil
 , unitless
@@ -65,13 +64,10 @@ import Clay.Stylesheet
 
 -------------------------------------------------------------------------------
 
--- | Sizes can be relative like ems or rems.
-data Rel
+-- | Sizes can be given using a length unit (e.g. em, px).
+data LengthUnit
 
--- | Sizes can be absolute like pixels, points, etc.
-data Abs
-
--- | Sizes can be given in percentages
+-- | Sizes can be given in percentages.
 data Percentage
 
 newtype Size a = Size Value
@@ -85,7 +81,7 @@ nil = Size "0"
 unitless :: Double -> Size a
 unitless i = Size (value i)
 
-cm, mm, inches, px, pt, pc :: Double -> Size Abs
+cm, mm, inches, px, pt, pc :: Double -> Size LengthUnit
 
 -- | Size in centimeters.
 cm i = Size (value i <> "cm")
@@ -105,17 +101,13 @@ pt i = Size (value i <> "pt")
 -- | Size in picas (1pc = 12pt).
 pc i = Size (value i <> "pc")
 
-pct :: Double -> Size Percentage
-em, ex, rem, vw, vh, vmin, vmax :: Double -> Size Rel
+em, ex, rem, vw, vh, vmin, vmax :: Double -> Size LengthUnit
 
 -- | Size in em's (computed value of the font-size).
 em i = Size (value i <> "em")
 
 -- | Size in ex'es (x-height of the first avaliable font).
 ex i = Size (value i <> "ex")
-
--- | Size in percents.
-pct i = Size (value i <> "%")
 
 -- | Size in rem's (em's, but always relative to the root element).
 rem i = Size (value i <> "rem")
@@ -132,7 +124,11 @@ vmin i = Size (value i <> "vmin")
 -- | Size in vmax's (the larger of vw or vh).
 vmax i = Size (value i <> "vmax")
 
-instance Num (Size Abs) where
+-- | Size in percents.
+pct :: Double -> Size Percentage
+pct i = Size (value i <> "%")
+
+instance Num (Size LengthUnit) where
   fromInteger = px . fromInteger
   (+)    = error   "plus not implemented for Size"
   (*)    = error  "times not implemented for Size"
@@ -140,7 +136,7 @@ instance Num (Size Abs) where
   signum = error "signum not implemented for Size"
   negate = error "negate not implemented for Size"
 
-instance Fractional (Size Abs) where
+instance Fractional (Size LengthUnit) where
   fromRational = px . fromRational
   recip  = error  "recip not implemented for Size"
 

--- a/src/Clay/Transform.hs
+++ b/src/Clay/Transform.hs
@@ -85,18 +85,19 @@ rotate3d :: Double -> Double -> Double -> Angle a -> Transformation
 rotate3d x y z a = Transformation ("rotate3d(" <> value [value x, value y, value z, value a] <> ")")
 
 -------------------------------------------------------------------------------
-  
-translate :: Size LengthUnit -> Size LengthUnit -> Transformation
-translate x y = Transformation ("translate(" <> value [x, y] <> ")")
 
-translateX, translateY, translateZ :: Size LengthUnit -> Transformation
+translate :: Size a -> Size b -> Transformation
+translate x y = Transformation ("translate(" <> value [value x, value y] <> ")")
+
+translateX, translateY :: Size LengthUnit -> Transformation
+translateZ :: Size LengthUnit -> Transformation
 
 translateX x = Transformation ("translateX(" <> value x <> ")")
 translateY y = Transformation ("translateY(" <> value y <> ")")
 translateZ z = Transformation ("translateZ(" <> value z <> ")")
 
-translate3d :: Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Transformation
-translate3d x y z = Transformation ("translate3d(" <> value [x, y, z] <> ")")
+translate3d :: Size a -> Size b -> Size LengthUnit -> Transformation
+translate3d x y z = Transformation ("translate3d(" <> value [value x, value y, value z] <> ")")
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Transform.hs
+++ b/src/Clay/Transform.hs
@@ -85,17 +85,17 @@ rotate3d :: Double -> Double -> Double -> Angle a -> Transformation
 rotate3d x y z a = Transformation ("rotate3d(" <> value [value x, value y, value z, value a] <> ")")
 
 -------------------------------------------------------------------------------
-
-translate :: Size Abs -> Size Abs -> Transformation
+  
+translate :: Size LengthUnit -> Size LengthUnit -> Transformation
 translate x y = Transformation ("translate(" <> value [x, y] <> ")")
 
-translateX, translateY, translateZ :: Size Abs -> Transformation
+translateX, translateY, translateZ :: Size LengthUnit -> Transformation
 
 translateX x = Transformation ("translateX(" <> value x <> ")")
 translateY y = Transformation ("translateY(" <> value y <> ")")
 translateZ z = Transformation ("translateZ(" <> value z <> ")")
 
-translate3d :: Size Abs -> Size Abs -> Size Abs -> Transformation
+translate3d :: Size LengthUnit -> Size LengthUnit -> Size LengthUnit -> Transformation
 translate3d x y z = Transformation ("translate3d(" <> value [x, y, z] <> ")")
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
CSS doesn't seem to differentiate between relative and absolute units. It does, however, differentiate between lengths and percentages. I'm basing this on [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/length). 

The way clay does sizes prevents users from specifying e.g. a border width of 1em. They also could specify opacity of 1em, which shouldn't be possible.

For this reason I replaced `Size Rel` and `Size Abs` with `Size Percentage` and `Size LengthUnit`. Do you think the naming is good?

I also changed [translate to allow usage of percentages](https://developer.mozilla.org/en-US/docs/Web/CSS/transform) for X and Y coordinates.

Also, the changes will not be really backwards comaptible, but the use cases which would work with CSS should also work after this change.