### PR TITLE
Calc function for sizes

### DIFF
--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -34,3 +34,7 @@ spec = do
       (em 2 @+@ pt 2) `shouldSatisfy` hasAllPrefixes
     it "return calc for sum of different types" $
       sizeRepr (em 2 @+@ pct 10) `shouldBe` "calc(2em + 10%)"
+    it "returns calc for simple difference" $
+      sizeRepr (em 2 @-@ px 5) `shouldBe` "calc(2em - 5px)"
+    it "returns calc for combination of sum and difference" $
+      sizeRepr (em 2 @-@ px 5 @+@ pt 3) `shouldBe` "calc((2em - 5px) + 3pt)"

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -5,6 +5,7 @@ module Clay.SizeSpec where
 import Clay.Size
 import Clay.Property
 import Clay.Common
+import Clay.Color
 
 import Test.Hspec
 import Data.Text
@@ -55,3 +56,5 @@ spec = do
     it "returns correct calc for complicated expression" $
       sizeRepr (em 2 @+@ (px 3 @-@ pt 2 @/ 3) @* 4 @* 3 @/ 4 @+@ 2 *@ (vmax 3 @* 5 @+@ vmin 4))
         `shouldBe` "calc((2em + ((3 * (4 * (3px - (2pt / 3)))) / 4)) + (2 * ((5 * 3vmax) + 4vmin)))"
+    it "returns original value if other is used" $
+      other (value aqua) `shouldBe` (value aqua)

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -48,3 +48,10 @@ spec = do
       sizeRepr (vmax 5 @-@ em 2 @* 6) `shouldBe` "calc(5vmax - (6 * 2em))"
     it "behaves correctly with negatives" $
       sizeRepr (vmax (-5) @-@ em (-2) @* (-6)) `shouldBe` "calc(-5vmax - (-6 * -2em))"
+    it "return calc for simple division" $
+      sizeRepr (em 2 @/ 3) `shouldBe` "calc(2em / 3)"
+    it "returns calc for division with sum" $
+      sizeRepr (em 2 @/ 3 @+@ px 7) `shouldBe` "calc((2em / 3) + 7px)"
+    it "returns correct calc for complicated expression" $
+      sizeRepr (em 2 @+@ (px 3 @-@ pt 2 @/ 3) @* 4 @* 3 @/ 4 @+@ 2 *@ (vmax 3 @* 5 @+@ vmin 4))
+        `shouldBe` "calc((2em + ((3 * (4 * (3px - (2pt / 3)))) / 4)) + (2 * ((5 * 3vmax) + 4vmin)))"

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -32,3 +32,5 @@ spec = do
       sizeRepr (em 2 @+@ pt 1 @+@ px 3) `shouldBe` "calc((2em + 1pt) + 3px)"
     it "returns prefixed calc for simple sum" $
       (em 2 @+@ pt 2) `shouldSatisfy` hasAllPrefixes
+    it "return calc for sum of different types" $
+      sizeRepr (em 2 @+@ pct 10) `shouldBe` "calc(2em + 10%)"

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -1,0 +1,34 @@
+{-#LANGUAGE OverloadedStrings#-}
+
+module Clay.SizeSpec where
+
+import Clay.Size
+import Clay.Property
+import Clay.Common
+
+import Test.Hspec
+import Data.Text
+import Data.List
+
+sizeRepr :: Size a -> Text
+sizeRepr = plain . unValue . value
+
+hasAllPrefixes :: Val a => a -> Bool
+hasAllPrefixes a = checkPrefixed ((unValue . value) a) browsers
+  where checkPrefixed (Prefixed pa) (Prefixed pb) = sort (fmap fst pa) == sort (fmap fst pb)
+        checkPrefixed _ _ = False
+
+spec :: Spec
+spec = do
+  describe "simple sizes" $ do
+    it "returns 1px for (px 1)" $
+      sizeRepr (px 1) `shouldBe` "1px"
+    it "return 50% for (pct 50)" $
+      sizeRepr (pct 50) `shouldBe` "50%"
+  describe "calc addition" $ do
+    it "returns proper calc for simple sum" $
+      sizeRepr (em 2 @+@ px 1) `shouldBe` "calc(2em + 1px)"
+    it "returns calc for nested sum" $
+      sizeRepr (em 2 @+@ pt 1 @+@ px 3) `shouldBe` "calc((2em + 1pt) + 3px)"
+    it "returns prefixed calc for simple sum" $
+      (em 2 @+@ pt 2) `shouldSatisfy` hasAllPrefixes

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -38,3 +38,13 @@ spec = do
       sizeRepr (em 2 @-@ px 5) `shouldBe` "calc(2em - 5px)"
     it "returns calc for combination of sum and difference" $
       sizeRepr (em 2 @-@ px 5 @+@ pt 3) `shouldBe` "calc((2em - 5px) + 3pt)"
+    it "returns calc for simple multiplication" $
+      sizeRepr (3 *@ em 2) `shouldBe` "calc(3 * 2em)"
+    it "returns calc for reversed multiplication" $
+      sizeRepr (em 2 @* 3) `shouldBe` "calc(3 * 2em)"
+    it "returns calc for multiplication with sum" $
+      sizeRepr (em 2 @* 3 @+@ px 3) `shouldBe` "calc((3 * 2em) + 3px)"
+    it "returns calc for multiplication with difference" $
+      sizeRepr (vmax 5 @-@ em 2 @* 6) `shouldBe` "calc(5vmax - (6 * 2em))"
+    it "behaves correctly with negatives" $
+      sizeRepr (vmax (-5) @-@ em (-2) @* (-6)) `shouldBe` "calc(-5vmax - (-6 * -2em))"

--- a/src/Clay/Property.hs
+++ b/src/Clay/Property.hs
@@ -69,7 +69,10 @@ data E5 = E5
 instance HasResolution E5 where resolution _ = 100000
 
 instance Val Double where
-  value = fromString . showFixed' . realToFrac
+  value = Value . Plain . cssDoubleText
+
+cssDoubleText :: Double -> Text
+cssDoubleText = fromString . showFixed' . realToFrac
     where
       showFixed' :: Fixed E5 -> String
       showFixed' = showFixed True

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -3,6 +3,8 @@
   , OverloadedStrings
   , GeneralizedNewtypeDeriving
   , FlexibleInstances
+  , ExistentialQuantification
+  , StandaloneDeriving
   #-}
 module Clay.Size
 (
@@ -31,6 +33,10 @@ module Clay.Size
 , vmin
 , vmax
 
+-- * Calculation operators for calc
+
+, (@+@)
+
 -- * Shorthands for properties that can be applied separately to each box side.
 
 , sym
@@ -57,6 +63,7 @@ where
 
 import Data.Monoid
 import Prelude hiding (rem)
+import Data.Text (Text)
 
 import Clay.Common
 import Clay.Property
@@ -70,63 +77,77 @@ data LengthUnit
 -- | Sizes can be given in percentages.
 data Percentage
 
-newtype Size a = Size Value
-  deriving (Val, Auto, Normal, Inherit, None, Other)
+data Size a = SimpleSize Text | forall b c. SumSize (Size b) (Size c)
+
+deriving instance Show (Size a)
+
+sizeToText :: Size a -> Text
+sizeToText (SimpleSize txt) = txt
+sizeToText (SumSize a b) = "(" <> sizeToText a <> " + " <> sizeToText b <> ")"
+
+instance Val (Size a) where
+  value (SimpleSize a) = value a
+  value s@(SumSize _ _) = Value $ browsers <> Plain ("calc" <> sizeToText s)
+
+instance Auto (Size a) where auto = Clay.Common.auto
+instance Normal (Size a) where normal = Clay.Common.normal
+instance Inherit (Size a) where inherit = Clay.Common.inherit
+instance None (Size a) where none = Clay.Common.none
 
 -- | Zero size.
 nil :: Size a
-nil = Size "0"
+nil = SimpleSize "0"
 
 -- | Unitless size (as recommended for line-height).
 unitless :: Double -> Size a
-unitless i = Size (value i)
+unitless i = SimpleSize ((plain . unValue . value) i)
 
 cm, mm, inches, px, pt, pc :: Double -> Size LengthUnit
 
 -- | Size in centimeters.
-cm i = Size (value i <> "cm")
+cm i = SimpleSize (cssDoubleText i <> "cm")
 
 -- | Size in millimeters.
-mm i = Size (value i <> "mm")
+mm i = SimpleSize (cssDoubleText i <> "mm")
 
 -- | Size in inches (1in = 2.54 cm).
-inches i = Size (value i <> "in")
+inches i = SimpleSize (cssDoubleText i <> "in")
 
 -- | Size in pixels.
-px i = Size (value i <> "px")
+px i = SimpleSize (cssDoubleText i <> "px")
 
 -- | Size in points (1pt = 1/72 of 1in).
-pt i = Size (value i <> "pt")
+pt i = SimpleSize (cssDoubleText i <> "pt")
 
 -- | Size in picas (1pc = 12pt).
-pc i = Size (value i <> "pc")
+pc i = SimpleSize (cssDoubleText i <> "pc")
 
 em, ex, rem, vw, vh, vmin, vmax :: Double -> Size LengthUnit
 
--- | Size in em's (computed value of the font-size).
-em i = Size (value i <> "em")
+-- | Size in em's (computed cssDoubleText of the font-size).
+em i = SimpleSize (cssDoubleText i <> "em")
 
--- | Size in ex'es (x-height of the first avaliable font).
-ex i = Size (value i <> "ex")
+-- | SimpleSize in ex'es (x-height of the first avaliable font).
+ex i = SimpleSize (cssDoubleText i <> "ex")
 
--- | Size in rem's (em's, but always relative to the root element).
-rem i = Size (value i <> "rem")
+-- | SimpleSize in rem's (em's, but always relative to the root element).
+rem i = SimpleSize (cssDoubleText i <> "rem")
 
--- | Size in vw's (1vw = 1% of viewport width).
-vw i = Size (value i <> "vw")
+-- | SimpleSize in vw's (1vw = 1% of viewport width).
+vw i = SimpleSize (cssDoubleText i <> "vw")
 
--- | Size in vh's (1vh = 1% of viewport height).
-vh i = Size (value i <> "vh")
+-- | SimpleSize in vh's (1vh = 1% of viewport height).
+vh i = SimpleSize (cssDoubleText i <> "vh")
 
--- | Size in vmin's (the smaller of vw or vh).
-vmin i = Size (value i <> "vmin")
+-- | SimpleSize in vmin's (the smaller of vw or vh).
+vmin i = SimpleSize (cssDoubleText i <> "vmin")
 
--- | Size in vmax's (the larger of vw or vh).
-vmax i = Size (value i <> "vmax")
+-- | SimpleSize in vmax's (the larger of vw or vh).
+vmax i = SimpleSize (cssDoubleText i <> "vmax")
 
--- | Size in percents.
+-- | SimpleSize in percents.
 pct :: Double -> Size Percentage
-pct i = Size (value i <> "%")
+pct i = SimpleSize (cssDoubleText i <> "%")
 
 instance Num (Size LengthUnit) where
   fromInteger = px . fromInteger
@@ -151,6 +172,11 @@ instance Num (Size Percentage) where
 instance Fractional (Size Percentage) where
   fromRational = pct . fromRational
   recip  = error  "recip not implemented for Size"
+
+-- | Plus operator to combine sizes into calc function
+infixl 6 @+@
+(@+@) :: Size a -> Size a -> Size a
+a @+@ b = SumSize a b
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -40,6 +40,7 @@ module Clay.Size
 , (@-@)
 , (@*)
 , (*@)
+, (@/)
 
 -- * Shorthands for properties that can be applied separately to each box side.
 
@@ -88,7 +89,8 @@ data Size a =
   SimpleSize Text |
   forall b c. SumSize (Size b) (Size c) |
   forall b c. DiffSize (Size b) (Size c) |
-  MultSize Double (Size a)
+  MultSize Double (Size a) |
+  DivSize Double (Size a)
 
 deriving instance Show (Size a)
 
@@ -97,6 +99,7 @@ sizeToText (SimpleSize txt) = txt
 sizeToText (SumSize a b) = mconcat ["(", sizeToText a, " + ", sizeToText b, ")"]
 sizeToText (DiffSize a b) = mconcat ["(", sizeToText a, " - ", sizeToText b, ")"]
 sizeToText (MultSize a b) = mconcat ["(", cssDoubleText a, " * ", sizeToText b, ")"]
+sizeToText (DivSize a b) = mconcat ["(", sizeToText b, " / ", cssDoubleText a, ")"]
 
 instance Val (Size a) where
   value (SimpleSize a) = value a
@@ -212,6 +215,11 @@ a *@ b = MultSize a b
 infixl 7 @*
 (@*) :: Size a -> Double -> Size a
 a @* b = MultSize b a
+
+-- | Division operator to combine sizes into calc function
+infixl 7 @/
+(@/) :: Size a -> Double -> Size a
+a @/ b = DivSize b a
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -38,6 +38,8 @@ module Clay.Size
 
 , (@+@)
 , (@-@)
+, (@*)
+, (*@)
 
 -- * Shorthands for properties that can be applied separately to each box side.
 
@@ -85,7 +87,8 @@ data Combination
 data Size a =
   SimpleSize Text |
   forall b c. SumSize (Size b) (Size c) |
-  forall b c. DiffSize (Size b) (Size c)
+  forall b c. DiffSize (Size b) (Size c) |
+  MultSize Double (Size a)
 
 deriving instance Show (Size a)
 
@@ -93,6 +96,7 @@ sizeToText :: Size a -> Text
 sizeToText (SimpleSize txt) = txt
 sizeToText (SumSize a b) = mconcat ["(", sizeToText a, " + ", sizeToText b, ")"]
 sizeToText (DiffSize a b) = mconcat ["(", sizeToText a, " - ", sizeToText b, ")"]
+sizeToText (MultSize a b) = mconcat ["(", cssDoubleText a, " * ", sizeToText b, ")"]
 
 instance Val (Size a) where
   value (SimpleSize a) = value a
@@ -182,6 +186,7 @@ instance Fractional (Size Percentage) where
   fromRational = pct . fromRational
   recip  = error  "recip not implemented for Size"
 
+-- | Type family to define what is the result of a calc operation
 
 type family SizeCombination sa sb where
   SizeCombination Percentage Percentage = Percentage
@@ -197,6 +202,16 @@ a @+@ b = SumSize a b
 infixl 6 @-@
 (@-@) :: Size a -> Size b -> Size (SizeCombination a b)
 a @-@ b = DiffSize a b
+
+-- | Times operator to combine sizes into calc function
+infixl 7 *@
+(*@) :: Double -> Size a -> Size a
+a *@ b = MultSize a b
+
+-- | Reversed times operator to combine sizes into calc function
+infixl 7 @*
+(@*) :: Size a -> Double -> Size a
+a @* b = MultSize b a
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -37,6 +37,7 @@ module Clay.Size
 -- * Calculation operators for calc
 
 , (@+@)
+, (@-@)
 
 -- * Shorthands for properties that can be applied separately to each box side.
 
@@ -81,17 +82,21 @@ data Percentage
 -- | When combining percentages with units using calc, we get a combination
 data Combination
 
-data Size a = SimpleSize Text | forall b c. SumSize (Size b) (Size c)
+data Size a =
+  SimpleSize Text |
+  forall b c. SumSize (Size b) (Size c) |
+  forall b c. DiffSize (Size b) (Size c)
 
 deriving instance Show (Size a)
 
 sizeToText :: Size a -> Text
 sizeToText (SimpleSize txt) = txt
-sizeToText (SumSize a b) = "(" <> sizeToText a <> " + " <> sizeToText b <> ")"
+sizeToText (SumSize a b) = mconcat ["(", sizeToText a, " + ", sizeToText b, ")"]
+sizeToText (DiffSize a b) = mconcat ["(", sizeToText a, " - ", sizeToText b, ")"]
 
 instance Val (Size a) where
   value (SimpleSize a) = value a
-  value s@(SumSize _ _) = Value $ browsers <> Plain ("calc" <> sizeToText s)
+  value s = Value $ browsers <> Plain ("calc" <> sizeToText s)
 
 instance Auto (Size a) where auto = Clay.Common.auto
 instance Normal (Size a) where normal = Clay.Common.normal
@@ -187,6 +192,11 @@ type family SizeCombination sa sb where
 infixl 6 @+@
 (@+@) :: Size a -> Size b -> Size (SizeCombination a b)
 a @+@ b = SumSize a b
+
+-- | Minus operator to combine sizes into calc function
+infixl 6 @-@
+(@-@) :: Size a -> Size b -> Size (SizeCombination a b)
+a @-@ b = DiffSize a b
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -90,7 +90,8 @@ data Size a =
   forall b c. SumSize (Size b) (Size c) |
   forall b c. DiffSize (Size b) (Size c) |
   MultSize Double (Size a) |
-  DivSize Double (Size a)
+  DivSize Double (Size a) |
+  OtherSize Value
 
 deriving instance Show (Size a)
 
@@ -100,15 +101,18 @@ sizeToText (SumSize a b) = mconcat ["(", sizeToText a, " + ", sizeToText b, ")"]
 sizeToText (DiffSize a b) = mconcat ["(", sizeToText a, " - ", sizeToText b, ")"]
 sizeToText (MultSize a b) = mconcat ["(", cssDoubleText a, " * ", sizeToText b, ")"]
 sizeToText (DivSize a b) = mconcat ["(", sizeToText b, " / ", cssDoubleText a, ")"]
+sizeToText (OtherSize a) = plain $ unValue a
 
 instance Val (Size a) where
   value (SimpleSize a) = value a
+  value (OtherSize a) = a
   value s = Value $ browsers <> Plain ("calc" <> sizeToText s)
 
 instance Auto (Size a) where auto = Clay.Common.auto
 instance Normal (Size a) where normal = Clay.Common.normal
 instance Inherit (Size a) where inherit = Clay.Common.inherit
 instance None (Size a) where none = Clay.Common.none
+instance Other (Size a) where other a = OtherSize a
 
 -- | Zero size.
 nil :: Size a

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -5,6 +5,7 @@
   , FlexibleInstances
   , ExistentialQuantification
   , StandaloneDeriving
+  , TypeFamilies
   #-}
 module Clay.Size
 (
@@ -76,6 +77,9 @@ data LengthUnit
 
 -- | Sizes can be given in percentages.
 data Percentage
+
+-- | When combining percentages with units using calc, we get a combination
+data Combination
 
 data Size a = SimpleSize Text | forall b c. SumSize (Size b) (Size c)
 
@@ -173,9 +177,15 @@ instance Fractional (Size Percentage) where
   fromRational = pct . fromRational
   recip  = error  "recip not implemented for Size"
 
+
+type family SizeCombination sa sb where
+  SizeCombination Percentage Percentage = Percentage
+  SizeCombination LengthUnit LengthUnit = LengthUnit
+  SizeCombination a b = Combination
+
 -- | Plus operator to combine sizes into calc function
 infixl 6 @+@
-(@+@) :: Size a -> Size a -> Size a
+(@+@) :: Size a -> Size b -> Size (SizeCombination a b)
 a @+@ b = SumSize a b
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
My shot at implementing the calc function for sizes in clay. There are a couple things which should be cleared up:

* The naming, I chose `@+@`, `@-@`, `@*`, `*@` and `@/`. Do you think it's understandable enough? Or should there be a specific calc function to make it more obvious what it is?
* The `Other` instance is done using a special alternative in the `Size` type.
* There are new GHC extensions used: `TypeFamilies` and `ExistentialQuantification`. Both of them make it easier to make everything more type safe, but maybe there's a way without them?