### PR TITLE
add htmlInline config

### DIFF
--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -1,12 +1,18 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Clay.RenderSpec where
 
-import Clay.Render (renderWith, compact)
+import Clay.Render (renderWith, compact, htmlInline)
 import Data.Monoid
 import Test.Hspec
+import Clay
 
 spec :: Spec
 spec = do
     describe "compact" $ do
         it "with mempty produces empty compact CSS" $
             renderWith compact [] mempty `shouldBe` ""
+    describe "htmlInline" $ do
+        it "with rules produces compact inline css" $ do
+            let css = do background red
+                         color white
+            renderWith htmlInline [] css `shouldBe` "background:#ff0000;color:#ffffff"

--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -16,3 +16,7 @@ spec = do
             let css = do background red
                          color white
             renderWith htmlInline [] css `shouldBe` "background:#ff0000;color:#ffffff"
+        it "with discarded selectors" $ do
+            let css = body ? do background red
+                                color white
+            renderWith htmlInline [] css `shouldBe` "background:#ff0000;color:#ffffff"

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -272,6 +272,8 @@ properties cfg xs =
              in mconcat [ind, fromText k, pad, ":", sep cfg, fromText v]
 
 selector :: Config -> Selector -> Builder
+selector Config { lbrace = "", rbrace = "" } = rec
+  where rec _ = ""
 selector cfg = intersperse ("," <> newline cfg) . rec
   where rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
           case p of

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -4,6 +4,7 @@ module Clay.Render
 , pretty
 , compact
 , render
+, htmlInline
 , putCss
 , renderWith
 , renderSelector
@@ -36,6 +37,8 @@ data Config = Config
   { indentation    :: Builder
   , newline        :: Builder
   , sep            :: Builder
+  , lbrace         :: Builder
+  , rbrace         :: Builder
   , finalSemicolon :: Bool
   , warn           :: Bool
   , align          :: Bool
@@ -49,6 +52,8 @@ pretty = Config
   { indentation    = "  "
   , newline        = "\n"
   , sep            = " "
+  , lbrace         = "{"
+  , rbrace         = "}"
   , finalSemicolon = True
   , warn           = True
   , align          = True
@@ -62,6 +67,23 @@ compact = Config
   { indentation    = ""
   , newline        = ""
   , sep            = ""
+  , lbrace         = "{"
+  , rbrace         = "}"
+  , finalSemicolon = False
+  , warn           = False
+  , align          = False
+  , banner         = False
+  }
+
+-- | Configuration to print to a compacted unreadable CSS output for embedding inline with HTML.
+
+htmlInline :: Config
+htmlInline = Config
+  { indentation    = ""
+  , newline        = ""
+  , sep            = ""
+  , lbrace         = ""
+  , rbrace         = ""
   , finalSemicolon = False
   , warn           = False
   , align          = False
@@ -110,10 +132,10 @@ kframe cfg (Keyframes ident xs) =
       mconcat [ "@" <> fromText browser <> "keyframes "
               , fromText ident
               , newline cfg
-              , "{"
+              , lbrace cfg
               , newline cfg
               , foldMap (frame cfg) xs
-              , "}"
+              , rbrace cfg
               , newline cfg
               , newline cfg
               ]
@@ -133,10 +155,10 @@ query cfg q sel rs =
   mconcat
     [ mediaQuery q
     , newline cfg
-    , "{"
+    , lbrace cfg
     , newline cfg
     , rules cfg sel rs
-    , "}"
+    , rbrace cfg
     , newline cfg
     ]
 
@@ -206,10 +228,10 @@ rule cfg sel props =
    in mconcat
       [ selector cfg (merger sel)
       , newline cfg
-      , "{"
+      , lbrace cfg
       , newline cfg
       , properties cfg xs
-      , "}"
+      , rbrace cfg
       , newline cfg
       ]
 


### PR DESCRIPTION
Fixes https://github.com/sebastiaanvisser/clay/issues/120

This PR extracts the `{` `}` opinion to fields in the Config type, and adds a new `htmlInline` config which avoids setting them.

NB. `inline` might be a better name, but it is already used by the `Display` module so I thought I'd avoid it.