### PR TITLE
Add the "sibling" selector combinator

### DIFF
--- a/src/Clay.hs
+++ b/src/Clay.hs
@@ -39,6 +39,7 @@ module Clay
 , (|>)
 , (#)
 , (|+)
+, (|~)
 
 -- ** Refining selectors.
 

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -304,6 +304,7 @@ selector cfg = intercalate ("," <> newline cfg) . rec
             Child      a b -> ins " > " <$> rec a <*> rec b
             Deep       a b -> ins " "   <$> rec a <*> rec b
             Adjacent   a b -> ins " + " <$> rec a <*> rec b
+            Sibling    a b -> ins " ~ " <$> rec a <*> rec b
             Combined   a b -> rec a ++ rec b
           where ins s a b = a <> s <> b
 

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -53,6 +53,11 @@ child a b = In (SelectorF (Refinement []) (Child a b))
 (|+) :: Selector -> Selector -> Selector
 (|+) a b = In (SelectorF (Refinement []) (Adjacent a b))
 
+-- | The general sibling selector composer. Maps to @sel1 ~ sel2@ in CSS.
+
+(|~) :: Selector -> Selector -> Selector
+(|~) a b = In (SelectorF (Refinement []) (Sibling a b))
+
 -- | Named alias for `#`.
 
 with :: Selector -> Refinement -> Selector
@@ -176,6 +181,7 @@ data Path f
   | Child     f f
   | Deep      f f
   | Adjacent  f f
+  | Sibling   f f
   | Combined  f f
   deriving Show
 


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/CSS/General_sibling_selectors

> The ~ combinator separates two selectors and matches the second
> element only if it is preceded by the first, and both share a common
> parent.
