### PR TITLE
bump hspec major version

### DIFF
--- a/clay.cabal
+++ b/clay.cabal
@@ -83,5 +83,5 @@ Test-Suite Test-Clay
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
     hspec-expectations   >= 0.7.2 && < 0.9,
-    hspec                >= 2.2.0 && < 2.3
+    hspec                >= 2.2.0 && < 2.5
   Ghc-Options: -Wall


### PR DESCRIPTION
With nixpkgs 8bc0ece at the latest, the default hspec version is 2.4.1. Clay builds and passes the tests just fine with this version, so I've bumped the dependency in clay.cabal rather than jailbreaking the nix expression.