### PR TITLE
Fix stepStop to be stepEnd

### DIFF
--- a/src/Clay/Transition.hs
+++ b/src/Clay/Transition.hs
@@ -83,7 +83,10 @@ easeOut    = other "ease-out"
 easeInOut  = other "ease-in-out"
 linear     = other "linear"
 stepStart  = other "step-start"
-stepStop   = other "step-stop"
+stepEnd    = other "step-end"
+
+stepStop   = stepEnd
+{-# DEPRECATED stepStop "Use `stepEnd` instead." #-}
 
 stepsStart, stepsStop :: Integer -> TimingFunction
 


### PR DESCRIPTION
Fixes #143 

It may not be worth deprecating `stepStop` since in its current form it doesn't actually work. If anyone is using it, then their CSS is broken.