### PR TITLE
Not pseudo takes selector

### DIFF
--- a/src/Clay/Pseudo.hs
+++ b/src/Clay/Pseudo.hs
@@ -3,7 +3,10 @@ module Clay.Pseudo where
 
 import Data.Text (Text)
 
+import Clay.Render (renderSelector)
 import Clay.Selector
+
+import qualified Data.Text.Lazy as Lazy
 
 -- List of specific pseudo classes, from:
 -- https://developer.mozilla.org/en-US/docs/CSS/Pseudo-classes
@@ -53,11 +56,13 @@ root          = ":root"
 target        = ":target"
 valid         = ":valid"
 
-lang, nthChild, nthLastChild, nthLastOfType, nthOfType, not :: Text -> Refinement
+lang, nthChild, nthLastChild, nthLastOfType, nthOfType :: Text -> Refinement
 
 lang          n = func "lang"             [n]
 nthChild      n = func "nth-child"        [n]
 nthLastChild  n = func "nth-last-child"   [n]
 nthLastOfType n = func "nth-last-of-type" [n]
 nthOfType     n = func "nth-of-type"      [n]
-not           n = func "not"              [n]
+
+not :: Selector -> Refinement
+not r = func "not" [Lazy.toStrict (renderSelector r)]

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -160,10 +160,10 @@ newtype Refinement = Refinement { unFilter :: [Predicate] }
   deriving (Show, Monoid)
 
 instance IsString Refinement where
-  fromString = filterFromText . fromString
+  fromString = refinementFromText . fromString
 
-filterFromText :: Text -> Refinement
-filterFromText t = Refinement $
+refinementFromText :: Text -> Refinement
+refinementFromText t = Refinement $
   case Text.uncons t of
     Just ('#', s) -> [Id     s]
     Just ('.', s) -> [Class  s]

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -157,7 +157,7 @@ data Predicate
   deriving (Eq, Ord, Show)
 
 newtype Refinement = Refinement { unFilter :: [Predicate] }
-  deriving Show
+  deriving (Show, Monoid)
 
 instance IsString Refinement where
   fromString = filterFromText . fromString

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -195,14 +195,14 @@ data SelectorF a = SelectorF Refinement (Path a)
 type Selector = Fix SelectorF
 
 instance IsString (Fix SelectorF) where
-  fromString = text . fromString
+  fromString = selectorFromText . fromString
 
-text :: Text -> Selector
-text t = In $
+selectorFromText :: Text -> Selector
+selectorFromText t =
   case Text.uncons t of
-    Just ('#', s) -> SelectorF (Refinement [Id s]) Star
-    Just ('.', s) -> SelectorF (Refinement [Class s]) Star
-    _             -> SelectorF (Refinement []) (Elem t)
+    Just (c, _) | elem c ("#.:@" :: [Char])
+      -> with star (refinementFromText t)
+    _ -> In $ SelectorF (Refinement []) (Elem t)
 
 #if MIN_VERSION_base(4,9,0)
 instance Semigroup (Fix SelectorF) where


### PR DESCRIPTION
The `:not()` pseudo selector now takes a `Selector` as argument, not a `Text`. This is closer to the CSS semantics and allows reuse of Clay selector syntax.

Note that this change will break the API and needs a bump. You can still just use string literals as arguments with OverloadedStrings, so the impact is likely very limited. 

Additionally I made a small fix in the selector parser by reusing the refinement parser internally. This means now things like `":first-child"` and `"@data-foo"` will parse properly. (using `with star` internally).

Not super relevant for now, but `PseudoFunc` is modelled to always take `Text` arguments, which is somewhat weakly typed and requires the `:not()` selector to convert to text immediately. Better model the actual function arguments types (e.g. `Text | xn+k | Selector`) to allow future inspection / optimizations etc, but I'm pretty sure no one is relying on that any time soon.