### PR TITLE
Add `commenting` to annotate value with comment

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 CHANGELOG
 
+  RECENT
+  - Added commenting to append comment to a property.
+    Comments are displayed by default in pretty but not compact mode.
+
   0.10 -> 0.10.1
   - Expose a render function for single selectors.
   - Added super for vertical-align.

--- a/clay.cabal
+++ b/clay.cabal
@@ -43,6 +43,7 @@ Library
     Clay.Border
     Clay.Box
     Clay.Color
+    Clay.Comments
     Clay.Common
     Clay.Dynamic
     Clay.Display

--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -36,7 +36,7 @@ spec = do
                 withBanner "\n{\n  display : none /*  */;\n}\n\n\n"
         it "with comment produces no comment" $ do
             renderWith pretty [] ("test" `comment` display displayNone) `shouldBe`
-                withBanner "\n{\n  /* test */\n  display : none;\n}\n\n\n"
+                withBanner "\n{\n  display : none /* test */;\n}\n\n\n"
 
 withBanner :: Text -> Text
 withBanner = (<> "/* Generated with Clay, http://fvisser.nl/clay */")

--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -4,6 +4,9 @@ module Clay.RenderSpec where
 import Clay.Render (renderWith, compact, htmlInline)
 import Test.Hspec
 import Clay
+import Clay.Stylesheet (comment)
+import Data.Monoid ((<>))
+import Data.Text.Lazy (Text)
 
 spec :: Spec
 spec = do
@@ -19,3 +22,21 @@ spec = do
             let css = body ? do background red
                                 color white
             renderWith htmlInline [] css `shouldBe` "background:#ff0000;color:#ffffff"
+    describe "compact comment" $ do
+        it "with mempty produces no annotation" $ do
+            renderWith compact [] (mempty `comment` display displayNone) `shouldBe` "{display:none}"
+        it "with comment produces no comment" $ do
+            renderWith compact [] ("test" `comment` display displayNone) `shouldBe` "{display:none}"
+    describe "pretty comment" $ do
+        it "with no comment produces no annotation" $ do
+            renderWith pretty [] (display displayNone) `shouldBe`
+                withBanner "\n{\n  display : none;\n}\n\n\n"
+        it "with mempty produces empty annotation" $ do
+            renderWith pretty [] (mempty `comment` display displayNone) `shouldBe`
+                withBanner "\n{\n  display : none /*  */;\n}\n\n\n"
+        it "with comment produces no comment" $ do
+            renderWith pretty [] ("test" `comment` display displayNone) `shouldBe`
+                withBanner "\n{\n  /* test */\n  display : none;\n}\n\n\n"
+
+withBanner :: Text -> Text
+withBanner = (<> "/* Generated with Clay, http://fvisser.nl/clay */")

--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -4,7 +4,7 @@ module Clay.RenderSpec where
 import Clay.Render (renderWith, compact, htmlInline)
 import Test.Hspec
 import Clay
-import Clay.Stylesheet (comment)
+import Clay.Comments
 import Data.Monoid ((<>))
 import Data.Text.Lazy (Text)
 
@@ -22,20 +22,20 @@ spec = do
             let css = body ? do background red
                                 color white
             renderWith htmlInline [] css `shouldBe` "background:#ff0000;color:#ffffff"
-    describe "compact comment" $ do
+    describe "compact ‘commenting’" $ do
         it "with mempty produces no annotation" $ do
-            renderWith compact [] (mempty `comment` display displayNone) `shouldBe` "{display:none}"
-        it "with comment produces no comment" $ do
-            renderWith compact [] ("test" `comment` display displayNone) `shouldBe` "{display:none}"
-    describe "pretty comment" $ do
-        it "with no comment produces no annotation" $ do
+            renderWith compact [] (mempty `commenting` display displayNone) `shouldBe` "{display:none}"
+        it "with ‘commenting’ produces no comment" $ do
+            renderWith compact [] ("test" `commenting` display displayNone) `shouldBe` "{display:none}"
+    describe "pretty ‘commenting’" $ do
+        it "with no ‘commenting’ produces no annotation" $ do
             renderWith pretty [] (display displayNone) `shouldBe`
                 withBanner "\n{\n  display : none;\n}\n\n\n"
         it "with mempty produces empty annotation" $ do
-            renderWith pretty [] (mempty `comment` display displayNone) `shouldBe`
+            renderWith pretty [] (mempty `commenting` display displayNone) `shouldBe`
                 withBanner "\n{\n  display : none /*  */;\n}\n\n\n"
-        it "with comment produces no comment" $ do
-            renderWith pretty [] ("test" `comment` display displayNone) `shouldBe`
+        it "with ‘commenting’ produces no comment" $ do
+            renderWith pretty [] ("test" `commenting` display displayNone) `shouldBe`
                 withBanner "\n{\n  display : none /* test */;\n}\n\n\n"
 
 withBanner :: Text -> Text

--- a/src/Clay.hs
+++ b/src/Clay.hs
@@ -22,6 +22,10 @@ module Clay
 
 , (-:)
 
+-- ** Comments
+-- $comments
+, commenting
+
 -- * The selector language.
 
 , Selector
@@ -138,6 +142,7 @@ import Clay.Border
 import Clay.Box
 import Clay.Color
 import Clay.Time
+import Clay.Comments (commenting)
 import Clay.Common
 import Clay.Display    hiding (table)
 import Clay.Dynamic
@@ -160,3 +165,19 @@ import Clay.Filter     hiding (url, opacity)
 -- Because a large part of the names export by "Clay.Media" clash with names
 -- export by other modules we don't re-export it here and recommend you to
 -- import the module qualified.
+
+-- $comments
+--
+-- It is occasionally useful to output comments in the generated css.
+-- 'commenting' appends comments (surrounded by '@ /* @' and '@ */@') to the
+-- values of the supplied 'Css' as
+--
+-- > key: value /* comment */;
+--
+-- Placing the comments before the semicolon ensures they are obviously
+-- grouped with the preceding value when rendered compactly.
+--
+-- Note that /every/ generated line in the generated content will feature the
+-- comment. 
+--
+-- An empty comment generates '@/*  */@'.

--- a/src/Clay/Comments.hs
+++ b/src/Clay/Comments.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE
+    GeneralizedNewtypeDeriving
+  #-}
+
+module Clay.Comments where
+
+import Data.String (IsString)
+import Data.Text (Text)
+
+newtype CommentText = CommentText { unCommentText :: Text }
+  deriving (Show, IsString)

--- a/src/Clay/Comments.hs
+++ b/src/Clay/Comments.hs
@@ -4,8 +4,10 @@
 
 module Clay.Comments where
 
+import Data.Monoid
+import Data.Semigroup
 import Data.String (IsString)
 import Data.Text (Text)
 
 newtype CommentText = CommentText { unCommentText :: Text }
-  deriving (Show, IsString)
+  deriving (Show, IsString, Semigroup, Monoid)

--- a/src/Clay/Comments.hs
+++ b/src/Clay/Comments.hs
@@ -1,13 +1,22 @@
-{-# LANGUAGE
-    GeneralizedNewtypeDeriving
-  #-}
-
 module Clay.Comments where
 
-import Data.Monoid
-import Data.Semigroup
-import Data.String (IsString)
-import Data.Text (Text)
+import Data.Monoid ((<>))
 
-newtype CommentText = CommentText { unCommentText :: Text }
-  deriving (Show, IsString, Semigroup, Monoid)
+import Clay.Stylesheet
+
+-- | Annotate the supplied 'Css' with the supplied comment.
+-- Comments work with 'OverloadedStrings'. This will annotate every non-nested
+-- value.
+commenting :: CommentText -> Css -> Css
+commenting c css = foldMap (rule . addComment c) $ runS css
+infixl 3 `commenting`
+
+-- The last case indicates there may be something wrong in the typing, as
+-- it shouldn't be possible to comment a wrong rule. In practice, this implementation
+-- means only the directly applied property rule is affected, i.e. no nested
+-- rules. That could be changed by adding recursive cases.
+addComment :: CommentText -> Rule -> Rule
+addComment c (Property Nothing k v  ) = Property (Just c) k v
+addComment c (Property (Just c0) k v) = Property (Just $ c <> c0) k v
+addComment _ r                        = r
+

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -24,7 +24,6 @@ import qualified Data.Text              as Text
 import qualified Data.Text.Lazy         as Lazy
 import qualified Data.Text.Lazy.IO      as Lazy
 
-import           Clay.Comments
 import           Clay.Common            (browsers)
 import           Clay.Property
 import           Clay.Selector

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -9,6 +9,7 @@ import Data.Text (Text)
 
 import Clay.Selector hiding (Child)
 import Clay.Property
+import Clay.Comments
 import Clay.Common
 
 -------------------------------------------------------------------------------
@@ -39,7 +40,7 @@ data Keyframes = Keyframes Text [(Double, [Rule])]
   deriving Show
 
 data Rule
-  = Property (Key ()) Value
+  = Property (Maybe CommentText) (Key ()) Value
   | Nested   App [Rule]
   | Query    MediaQuery [Rule]
   | Face     [Rule]
@@ -71,7 +72,7 @@ instance Monoid Css where
 -- words: can be converted to a `Value`.
 
 key :: Val a => Key a -> a -> Css
-key k v = rule $ Property (cast k) (value v)
+key k v = rule $ Property Nothing (cast k) (value v)
 
 -- | Add a new style property to the stylesheet with the specified `Key` and
 -- value, like `key` but use a `Prefixed` key.

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -89,6 +89,17 @@ infix 4 -:
 (-:) :: Key Text -> Text -> Css
 (-:) = key
 
+comment :: CommentText -> Css -> Css
+comment c css = foldMap (rule . addComment c) $ runS css
+infixl 3 `comment`
+
+-- TODO The last case indicates there's something wrong in the typing, as
+-- it shouldn't be possible to comment a wrong rule.
+addComment :: CommentText -> Rule -> Rule
+addComment c (Property Nothing k v  ) = Property (Just c) k v
+addComment c (Property (Just c0) k v) = Property (Just $ c <> c0) k v
+addComment _ r                        = r
+
 -------------------------------------------------------------------------------
 
 infixr 5 <?

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -5,11 +5,12 @@ module Clay.Stylesheet where
 import Control.Applicative
 import Control.Arrow (second)
 import Control.Monad.Writer hiding (All)
+import Data.Semigroup (Semigroup)
+import Data.String (IsString)
 import Data.Text (Text)
 
 import Clay.Selector hiding (Child)
 import Clay.Property
-import Clay.Comments
 import Clay.Common
 
 -------------------------------------------------------------------------------
@@ -25,6 +26,9 @@ data MediaQuery = MediaQuery (Maybe NotOrOnly) MediaType [Feature]
 
 data Feature = Feature Text (Maybe Value)
   deriving Show
+
+newtype CommentText = CommentText { unCommentText :: Text }
+  deriving (Show, IsString, Semigroup, Monoid)
 
 -------------------------------------------------------------------------------
 
@@ -88,17 +92,6 @@ infix 4 -:
 
 (-:) :: Key Text -> Text -> Css
 (-:) = key
-
-comment :: CommentText -> Css -> Css
-comment c css = foldMap (rule . addComment c) $ runS css
-infixl 3 `comment`
-
--- TODO The last case indicates there's something wrong in the typing, as
--- it shouldn't be possible to comment a wrong rule.
-addComment :: CommentText -> Rule -> Rule
-addComment c (Property Nothing k v  ) = Property (Just c) k v
-addComment c (Property (Just c0) k v) = Property (Just $ c <> c0) k v
-addComment _ r                        = r
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR adds a new function `commenting` which annotates a value with a comment. For example,

```haskell
commenting :: CommentText -> Css -> Css
infixl 3 `commenting`

"A comment" `commenting` display displayNone
``` 

becomes

```css
{
    display: none /* A comment */;
}
```

Only the `pretty` configuration is set to include comments by default.

The implementation means that if the supplied `Css` has multiple properties, all those in the top level will be annotated.

This does some of #149 (the relatively straightforward bit).

I'd be grateful to have this merged, if you are happy to do so, as soon as possible, as I'd like to use the new feature for updates to a downstream library (jgm/skylighting#27).