### PR TITLE
Add 'important' to annotate property with ‘important!

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ CHANGELOG
   RECENT
   - Added commenting to append comment to a property.
     Comments are displayed by default in pretty but not compact mode.
+  - Added 'important' to append !important to values.
 
   0.10 -> 0.10.1
   - Expose a render function for single selectors.

--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -37,6 +37,9 @@ spec = do
         it "with ‘commenting’ produces no comment" $ do
             renderWith pretty [] ("test" `commenting` display displayNone) `shouldBe`
                 withBanner "\n{\n  display : none /* test */;\n}\n\n\n"
+    describe "!important" $ do
+        it "renders !important" $ do
+            renderWith compact [] (important $ background red) `shouldBe` "{background:#ff0000 !important}"
 
 withBanner :: Text -> Text
 withBanner = (<> "/* Generated with Clay, http://fvisser.nl/clay */")

--- a/src/Clay.hs
+++ b/src/Clay.hs
@@ -73,7 +73,11 @@ module Clay
 
 , fontFace
 
--- * Import other CSS files
+-- * !important
+
+, important
+
+-- * Import other CSS files
 
 , importUrl
 


### PR DESCRIPTION
Use is very similar to `commenting`. This change actually touches all the areas that change did, and improves the implementation (specifically, the `Modifier` type makes the `Property` constructor far clearer).

Also includes test suite and changelog additions.

Fixes #107.

This does interact slightly with #158 so if you want to merge both, I'd be happy to rebase this, first.