### PR TITLE
Rewrite boxShadow functionality using BoxShadow newtype

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ CHANGELOG
   RECENT
   - Added commenting to append comment to a property.
     Comments are displayed by default in pretty but not compact mode.
+  - Rewrite boxShadow functionality with BoxShadow newtype for arguments.
 
   0.10 -> 0.10.1
   - Expose a render function for single selectors.

--- a/spec/Clay/BoxSpec.hs
+++ b/spec/Clay/BoxSpec.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+module Clay.BoxSpec where
+
+import Test.Hspec
+import Clay
+import Common
+
+spec :: Spec
+spec = do
+  describe "box-shadow (Mozilla examples)" $ do
+    describe "none" $ do
+      "{box-shadow:none}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:none;-moz-box-shadow:none;-ms-box-shadow:none;-o-box-shadow:none;box-shadow:none}" $
+          boxShadow [none]
+
+    describe "offset-x | offset-y | color" $ do
+      "{box-shadow:60px -16px teal}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:60px -16px #008080;-moz-box-shadow:60px -16px #008080;-ms-box-shadow:60px -16px #008080;-o-box-shadow:60px -16px #008080;box-shadow:60px -16px #008080}" $
+          boxShadow . pure . bsColor teal $ shadow (px 60) (px (-16))
+
+    describe "offset-x | offset-y | blur-radius | color" $ do
+      "{box-shadow:10px 5px 5px black}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:10px 5px 5px #000000;-moz-box-shadow:10px 5px 5px #000000;-ms-box-shadow:10px 5px 5px #000000;-o-box-shadow:10px 5px 5px #000000;box-shadow:10px 5px 5px #000000}" $
+          boxShadow [bsColor black $ shadowWithBlur (px 10) (px 5) (px 5)]
+
+    describe "offset-x | offset-y | blur-radius | spread-radius | color" $ do
+      "{box-shadow:2px 2px 2px 1px rgba(0, 0, 0, 0.2)}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:2px 2px 2px 1px rgba(0,0,0,0.2);-moz-box-shadow:2px 2px 2px 1px rgba(0,0,0,0.2);-ms-box-shadow:2px 2px 2px 1px rgba(0,0,0,0.2);-o-box-shadow:2px 2px 2px 1px rgba(0,0,0,0.2);box-shadow:2px 2px 2px 1px rgba(0,0,0,0.2)}" $
+          boxShadow [rgba 0 0 0 0.2 `bsColor` shadowWithSpread (px 2) (px 2) (px 2) (px 1)]
+
+    describe "inset | offset-x | offset-y | color" $ do
+      "{box-shadow:inset 5em 1em gold}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:inset 5em 1em #ffd700;-moz-box-shadow:inset 5em 1em #ffd700;-ms-box-shadow:inset 5em 1em #ffd700;-o-box-shadow:inset 5em 1em #ffd700;box-shadow:inset 5em 1em #ffd700}" $
+          boxShadow [bsInset $ gold `bsColor` shadow (em 5) (em 1)]
+
+    describe "Any number of shadows, separated by commas" $ do
+      "{box-shadow:3px 3px red, -1em 0 0.4em olive}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:3px 3px #ff0000,-1em 0 0.4em #808000;-moz-box-shadow:3px 3px #ff0000,-1em 0 0.4em #808000;-ms-box-shadow:3px 3px #ff0000,-1em 0 0.4em #808000;-o-box-shadow:3px 3px #ff0000,-1em 0 0.4em #808000;box-shadow:3px 3px #ff0000,-1em 0 0.4em #808000}" $
+          boxShadow
+          [ red `bsColor` shadow (px 3) (px 3)
+          , olive `bsColor` shadowWithBlur (em (-1)) nil (em 0.4)
+          ]
+
+    describe "Global keywords" $ do
+      "{box-shadow:inherit}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:inherit;-moz-box-shadow:inherit;-ms-box-shadow:inherit;-o-box-shadow:inherit;box-shadow:inherit}" $
+          boxShadow [inherit]
+      "{box-shadow:initial}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:initial;-moz-box-shadow:initial;-ms-box-shadow:initial;-o-box-shadow:initial;box-shadow:initial}" $
+          boxShadow [initial]
+      "{box-shadow:unset}" `shouldRenderAsFrom`
+        "{-webkit-box-shadow:unset;-moz-box-shadow:unset;-ms-box-shadow:unset;-o-box-shadow:unset;box-shadow:unset}" $
+          boxShadow [unset]

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -1,0 +1,21 @@
+module Common where
+
+import Clay.Render (renderWith, compact)
+import Test.Hspec
+import Clay
+import Data.Monoid ((<>))
+import Data.Text.Lazy (Text, unpack)
+
+shouldRenderFrom :: Text -> Css -> SpecWith ()
+shouldRenderFrom txt css =
+  it ("renders " <> unpack txt) $ txt `shouldRenderItFrom` css
+infixr 0 `shouldRenderFrom`
+
+shouldRenderAsFrom :: String -> Text -> Css -> SpecWith ()
+shouldRenderAsFrom des txt css =
+  it ("renders " <> des) $ txt `shouldRenderItFrom` css
+infixr 3 `shouldRenderAsFrom`
+
+shouldRenderItFrom :: Text -> Css -> Expectation
+shouldRenderItFrom = flip $ shouldBe . renderWith compact []
+infixr 0 `shouldRenderItFrom`

--- a/src/Clay/Box.hs
+++ b/src/Clay/Box.hs
@@ -3,7 +3,17 @@ module Clay.Box
 ( BoxType
 , paddingBox, borderBox, contentBox
 , boxSizing
+-- * @box-shadow@
+-- $box-shadow
 , boxShadow
+, shadow
+, shadowWithBlur
+, shadowWithSpread
+, bsInset
+, bsColor
+-- ** Deprecated
+-- $box-shadow-deprecated
+, boxShadow'
 , boxShadowWithSpread
 , boxShadows
 , insetBoxShadow
@@ -11,6 +21,7 @@ module Clay.Box
 where
 
 import Data.Monoid
+import Data.List.NonEmpty (NonEmpty)
 
 import Clay.Color
 import Clay.Common
@@ -37,17 +48,127 @@ boxSizing = prefixed (browsers <> "box-sizing")
 
 -------------------------------------------------------------------------------
 
-boxShadow :: Size a -> Size a -> Size a -> Color -> Css
-boxShadow x y w c = prefixed (browsers <> "box-shadow") (x ! y ! w ! c)
+-- $box-shadow
+--
+-- === Formal argument syntax
+--
+-- > none | <shadow>#
+-- > where 
+-- > <shadow> = inset? && <length>{2,4} && <color>?
+-- > 
+-- > where 
+-- > <color> = <rgb()> | <rgba()> | <hsl()> | <hsla()> | <hex-color> | <named-color> | currentcolor | <deprecated-system-color>
+-- > 
+-- > where 
+-- > <rgb()> = rgb( [ [ <percentage>{3} | <number>{3} ] [ / <alpha-value> ]? ] | [ [ <percentage>#{3} | <number>#{3} ] , <alpha-value>? ] )
+-- > <rgba()> = rgba( [ [ <percentage>{3} | <number>{3} ] [ / <alpha-value> ]? ] | [ [ <percentage>#{3} | <number>#{3} ] , <alpha-value>? ] )
+-- > <hsl()> = hsl( [ <hue> <percentage> <percentage> [ / <alpha-value> ]? ] | [ <hue>, <percentage>, <percentage>, <alpha-value>? ] )
+-- > <hsla()> = hsla( [ <hue> <percentage> <percentage> [ / <alpha-value> ]? ] | [ <hue>, <percentage>, <percentage>, <alpha-value>? ] )
+-- > 
+-- > where 
+-- > <alpha-value> = <number> | <percentage>
+-- > <hue> = <number> | <angle>
 
-boxShadowWithSpread :: Size a -> Size a -> Size a -> Size a -> Color -> Css
-boxShadowWithSpread x y blurRadius spreadRadius color =
-    prefixed (browsers <> "box-shadow") (x ! y ! blurRadius ! spreadRadius ! color)
+newtype BoxShadow = BoxShadow Value
+  deriving (Val, Inherit, Initial, Unset, None, Other)
 
-boxShadows :: [(Size a, Size a, Size a, Color)] -> Css
-boxShadows = prefixed (browsers <> "box-shadow") . map (\(a, b, c, d) -> a ! b ! c ! d)
+-- | This function will usually take a singleton list, but requiring a (non-empty)
+-- list prevents accidentally applying the modifiers ('bsInset', 'bsColor')
+-- incorrectly.
+--
+-- 'pure' (from "Control.Applicative") creates a singleton list.
+--
+-- > boxShadow . pure $ none
+-- > boxShadow . pure $ shadow (px 1) (px 1)
+--
+-- Use with @{-# LANGUAGE OverloadedLists #-}@ for the simplest list syntax.
+--
+-- > boxShadow [none]
+-- > boxShadow [shadow (px 1) (px 1)]
+--
+-- This is recommended for supplying multiple 'BoxShadow' values.
+--
+-- > boxShadow [shadowWithBlur (em 2) (em 1), bsInset . bsColor red $ shadow (px 1) (px 2)]
+boxShadow :: NonEmpty BoxShadow -> Css
+boxShadow = prefixed (browsers <> "box-shadow") . value
+
+shadow
+  :: Size a -- ^ Horizontal offset
+  -> Size a -- ^ Vertical offset
+  -> BoxShadow
+shadow x y = BoxShadow . value $ (x ! y)
+
+shadowWithBlur
+  :: Size a -- ^ Horizontal offset
+  -> Size a -- ^ Vertical offset
+  -> Size a -- ^ Blur radius
+  -> BoxShadow
+shadowWithBlur x y w = BoxShadow . value $ (x ! y ! w)
+
+-- | While this function is the correct type to work with the 'sym', 'sym2'
+-- or 'sym3' functions, such applications are unlikely to be meaningful.
+shadowWithSpread
+  :: Size a -- ^ Horizontal offset
+  -> Size a -- ^ Vertical offset
+  -> Size a -- ^ Blur radius
+  -> Size a -- ^ Spread radius
+  -> BoxShadow
+shadowWithSpread x y blurRadius spreadRadius =
+    BoxShadow . value $ (x ! y ! blurRadius ! spreadRadius)
+
+-- | Adapt the provided @box-shadow@ with the @inset@ prefix.
+-- 
+-- > boxShadow . pure . bsInset
+bsInset :: BoxShadow -> BoxShadow
+bsInset (BoxShadow v) = BoxShadow . value $ ("inset" :: Value, v)
+
+-- | Supply a color to the provided @box-shadow@.
+bsColor :: Color -> BoxShadow -> BoxShadow
+bsColor c (BoxShadow v) = BoxShadow . value $ (v, c)
+infixr 9 `bsColor`
 
 -------------------------------------------------------------------------------
 
+-- $box-shadow-deprecated
+--
+-- The old implementation was both restrictive and slightly off-spec. It
+-- shall be discontinued in a future release. The 'boxShadow' name has already
+-- been taken, so the functionality that used to provide is now provided by
+-- 'boxShadow\''.
+
+-- | This is the drop-in replacement for the old 'boxShadow' function (< 0.13).
+-- It is possible to continue for now
+boxShadow' :: Size a -> Size a -> Size a -> Color -> Css
+boxShadow' x y w c = prefixed (browsers <> "box-shadow") (x ! y ! w ! c)
+{-# DEPRECATED boxShadow' "This function is only present for compatibility purposes and will be removed." #-}
+
+-- | Replace calls to this function as follows (using -XOverloadedLists)
+--
+-- > boxShadowWithSpread x y rb rs c
+--
+-- > boxShadow [c `bsColor` shadowWithSpread x y rb rs]
+boxShadowWithSpread :: Size a -> Size a -> Size a -> Size a -> Color -> Css
+boxShadowWithSpread x y blurRadius spreadRadius color =
+    prefixed (browsers <> "box-shadow") (x ! y ! blurRadius ! spreadRadius ! color)
+{-# DEPRECATED boxShadowWithSpread "This function has been replaced with shadowWithSpread and bsColor and will be removed." #-}
+
+-- | Replace calls to this function as follows (using -XOverloadedLists)
+--
+-- > boxShadows [(x1, y1, rb1, c1), (x2, y2, rb2, c2)]
+--
+-- > boxShadow
+-- >   [ c1 `bsColor` shadowWithBlur x1 y1 rb1
+-- >   , c2 `bsColor` shadowWithBlur x2 y2 rb2
+-- >   ]
+boxShadows :: [(Size a, Size a, Size a, Color)] -> Css
+boxShadows = prefixed (browsers <> "box-shadow") . map (\(a, b, c, d) -> a ! b ! c ! d)
+{-# DEPRECATED boxShadows "This function is replaced with boxShadow and will be removed." #-}
+
+-- | Replace calls to this function as follows (using -XOverloadedLists)
+--
+-- > insetBoxShadow s x y rb c
+--
+-- > boxShadow [bsInset $ c `bsColor` shadowWithBlur x y rb]
 insetBoxShadow :: Stroke -> Size a -> Size a -> Size a -> Color -> Css
 insetBoxShadow x y w c z = prefixed (browsers <> "box-shadow") (x ! y ! w ! c ! z)
+{-# DEPRECATED insetBoxShadow "This function has been replaced with shadowWithSpread, bsInset and bsColor and will be removed." #-}

--- a/src/Clay/Property.hs
+++ b/src/Clay/Property.hs
@@ -5,6 +5,7 @@ import Control.Arrow (second)
 import Control.Monad.Writer
 import Data.Fixed (Fixed, HasResolution (resolution), showFixed)
 import Data.List (partition, sort)
+import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Maybe
 import Data.String
 import Data.Text (Text, replace)
@@ -93,6 +94,9 @@ instance (Val a, Val b) => Val (Either a b) where
 
 instance Val a => Val [a] where
   value xs = intersperse "," (map value xs)
+
+instance Val a => Val (NonEmpty a) where
+  value = value . toList
 
 intersperse :: Monoid a => a -> [a] -> a
 intersperse _ []     = mempty


### PR DESCRIPTION
Fixes #146 (also #144)

There is one breaking change (though the type error will make it obvious) to the type of `boxShadow`.
The rest of old API still available, though, with deprecation warnings.

-   `boxShadow` now takes a `NonEmpty` list of `BoxShadow` values.
-   Create `BoxShadow` values with the provided functions `shadow*`.
-   Modify using provided functions `bs*`.

Test suite + changelog included. The tests are a little noisy; there's probably an acceptable way to factor out all of the browser prefixes from the test results.

This does interact slightly with #158 and #159 so if you want to merge all three, I'd be happy to rebase this, first.