### PR TITLE
Add a bunch of instances.

### DIFF
--- a/clay.cabal
+++ b/clay.cabal
@@ -70,19 +70,21 @@ Library
 
   GHC-Options: -Wall
   Build-Depends:
-    base  >= 4.5  && < 5,
-    mtl   >= 1    && < 2.3,
-    text  >= 0.11 && < 1.3
+    base     >= 4.5  && < 5,
+    mtl      >= 1    && < 2.3,
+    text     >= 0.11 && < 1.3,
+    fixplate >= 0.1 && < 0.2
 
 Test-Suite Test-Clay
   Type: exitcode-stdio-1.0
   HS-Source-Dirs: spec, src
   main-is: Spec.hs
   Build-Depends:
-    base                 >= 4.5  && < 5,
+    base                 >= 4.5   && < 5,
     base                 >= 4     && < 5,
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
+    fixplate             >= 0.1   && < 0.2,
     hspec-expectations   >= 0.7.2 && < 0.9,
     hspec                >= 2.2.0 && < 2.5
   Ghc-Options: -Wall

--- a/nix/clay.nix
+++ b/nix/clay.nix
@@ -1,10 +1,11 @@
 { mkDerivation, base, hspec, hspec-expectations, mtl, stdenv, text
+, fixplate
 }:
 mkDerivation {
   pname = "clay";
   version = "0.13.0";
   src = ./..;
-  libraryHaskellDepends = [ base mtl text ];
+  libraryHaskellDepends = [ base mtl text fixplate ];
   testHaskellDepends = [ base hspec hspec-expectations mtl text ];
   homepage = "http://fvisser.nl/clay";
   description = "CSS preprocessor as embedded Haskell";

--- a/src/Clay/Property.hs
+++ b/src/Clay/Property.hs
@@ -10,7 +10,9 @@ import Data.Maybe
 import Data.String
 import Data.Text (Text, replace)
 
-data Prefixed = Prefixed { unPrefixed :: [(Text, Text)] } | Plain { unPlain :: Text }
+data Prefixed
+  = Prefixed { unPrefixed :: [(Text, Text)] }
+  | Plain { unPlain :: Text }
   deriving (Show, Eq)
 
 instance IsString Prefixed where
@@ -41,7 +43,7 @@ quote t = "\"" <> replace "\"" "\\\"" t <> "\""
 -------------------------------------------------------------------------------
 
 newtype Key a = Key { unKeys :: Prefixed }
-  deriving (Show, Monoid, IsString)
+  deriving (Show, Monoid, IsString,Eq)
 
 cast :: Key a -> Key ()
 cast (Key k) = Key k
@@ -58,7 +60,7 @@ instance Val Text where
   value t = Value (Plain t)
 
 newtype Literal = Literal Text
-  deriving (Show, Monoid, IsString)
+  deriving (Show, Monoid, IsString,Eq)
 
 instance Val Literal where
   value (Literal t) = Value (Plain (quote t))
@@ -111,4 +113,3 @@ infixr !
 
 (!) :: a -> b -> (a, b)
 (!) = (,)
-

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -21,6 +21,8 @@ import           Data.Text              (Text, pack)
 import           Data.Text.Lazy.Builder
 import           Prelude                hiding ((**))
 
+import           Data.Generics.Fixplate (Mu (Fix))
+
 import qualified Data.Text              as Text
 import qualified Data.Text.Lazy         as Lazy
 import qualified Data.Text.Lazy.IO      as Lazy
@@ -297,7 +299,7 @@ selector :: Config -> Selector -> Builder
 selector Config { lbrace = "", rbrace = "" } = rec
   where rec _ = ""
 selector cfg = intercalate ("," <> newline cfg) . rec
-  where rec (In (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
+  where rec (Fix (SelectorF (Refinement ft) p)) = (<> foldMap predicate (sort ft)) <$>
           case p of
             Star           -> if null ft then ["*"] else [""]
             Elem t         -> [fromText t]
@@ -322,4 +324,3 @@ predicate ft = mconcat $
     Pseudo       a   -> [ ":" , fromText a                                             ]
     PseudoFunc   a p -> [ ":" , fromText a, "(", intercalate "," (map fromText p), ")" ]
     PseudoElem   a   -> [ "::", fromText a                                             ]
-

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -1,42 +1,42 @@
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE ViewPatterns               #-}
 module Clay.Stylesheet where
 
-import Control.Applicative
-import Control.Arrow (second)
-import Control.Monad.Writer hiding (All)
-import Data.Maybe (isJust)
-import Data.Semigroup (Semigroup)
-import Data.String (IsString)
-import Data.Text (Text)
+import           Control.Applicative
+import           Control.Arrow        (second)
+import           Control.Monad.Writer hiding (All)
+import           Data.Maybe           (isJust)
+import           Data.Semigroup       (Semigroup)
+import           Data.String          (IsString)
+import           Data.Text            (Text)
 
-import Clay.Selector hiding (Child)
-import Clay.Property
-import Clay.Common
+import           Clay.Common
+import           Clay.Property
+import           Clay.Selector        hiding (Child)
 
 -------------------------------------------------------------------------------
 
 newtype MediaType = MediaType Value
-  deriving (Val, Other, Show, All)
+  deriving (Val, Other, Show, All, Eq)
 
 data NotOrOnly = Not | Only
-  deriving Show
+  deriving (Show,Eq)
 
 data MediaQuery = MediaQuery (Maybe NotOrOnly) MediaType [Feature]
-  deriving Show
+  deriving (Show,Eq)
 
 data Feature = Feature Text (Maybe Value)
-  deriving Show
+  deriving (Show,Eq)
 
 newtype CommentText = CommentText { unCommentText :: Text }
-  deriving (Show, IsString, Semigroup, Monoid)
+  deriving (Show, IsString, Semigroup, Monoid, Eq)
 
 data Modifier
   = Important
   | Comment CommentText
-  deriving (Show)
+  deriving (Show,Eq)
 
 _Important :: Modifier -> Maybe Text
 _Important Important   = Just "!important"
@@ -54,10 +54,10 @@ data App
   | Pop    Int
   | Child  Selector
   | Sub    Selector
-  deriving Show
+  deriving (Show,Eq)
 
 data Keyframes = Keyframes Text [(Double, [Rule])]
-  deriving Show
+  deriving (Show,Eq)
 
 data Rule
   = Property [Modifier] (Key ()) Value
@@ -66,7 +66,7 @@ data Rule
   | Face     [Rule]
   | Keyframe Keyframes
   | Import   Text
-  deriving Show
+  deriving (Show,Eq)
 
 newtype StyleM a = S (Writer [Rule] a)
   deriving (Functor, Applicative, Monad)


### PR DESCRIPTION
I'm trying to build support for Clay in another package, and I found the lack of particular instances to be a bit of a hindrance. This isn't in reference to a particular issue, just trying to help out a bit. :)

Added instances for 'Eq', 'Functor', and 'Foldable' for several of the data
types. This is to allow for a bit more flexibility when trying to build things
on top of this package. You can now compare two `Selector` values for equality,
for example. Should you need such a thing.

Also, replaced the custom `Fix` type with a prepacked one from the `fixplate`
package. Aside from leaning on already written code, there is a bunch of
NiceThings(TM) that come with the fixplate package.

I've included a `updateClasses` function as example.

I would like to utilise some features from `lens` as well. But I'm considering
making that a separate package as some people aren't a fan of pulling down the
entire package.