### PR TITLE
Fix build warnings related to Monoid and Semigroup

### DIFF
--- a/spec/Clay/BoxSpec.hs
+++ b/spec/Clay/BoxSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings, OverloadedLists #-}
 module Clay.BoxSpec where
 
-import Control.Applicative
 import Test.Hspec
 import Clay
 import Common

--- a/spec/Clay/RenderSpec.hs
+++ b/spec/Clay/RenderSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Clay.RenderSpec where
 
-import Data.Monoid
 import Clay.Render (htmlInline, withBanner)
 import Test.Hspec
 import Clay

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE CPP #-}
 module Common where
 
-import Clay.Render (renderWith, compact)
 import Test.Hspec
 import Clay
+#if __GLASGOW_HASKELL__ < 808
 import Data.Monoid ((<>))
+#endif
 import Data.Text.Lazy (Text, unpack)
 
 shouldRenderFrom :: Text -> Css -> SpecWith ()

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -1,11 +1,7 @@
-{-# LANGUAGE CPP #-}
 module Common where
 
 import Test.Hspec
 import Clay
-#if __GLASGOW_HASKELL__ < 808
-import Data.Monoid ((<>))
-#endif
 import Data.Text.Lazy (Text, unpack)
 
 shouldRenderFrom :: Text -> Css -> SpecWith ()

--- a/src/Clay/Box.hs
+++ b/src/Clay/Box.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.Box
 ( BoxType
 , paddingBox, borderBox, contentBox
@@ -20,9 +20,6 @@ module Clay.Box
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Data.List.NonEmpty (NonEmpty)
 
 import Clay.Color

--- a/src/Clay/Box.hs
+++ b/src/Clay/Box.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.Box
 ( BoxType
 , paddingBox, borderBox, contentBox
@@ -20,7 +20,9 @@ module Clay.Box
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Data.List.NonEmpty (NonEmpty)
 
 import Clay.Color

--- a/src/Clay/Color.hs
+++ b/src/Clay/Color.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
 module Clay.Color where
 
 import Data.Char (isHexDigit)
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Data.String
 import Text.Printf
 

--- a/src/Clay/Color.hs
+++ b/src/Clay/Color.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Clay.Color where
 
 import Data.Char (isHexDigit)
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Data.String
 import Text.Printf
 

--- a/src/Clay/Comments.hs
+++ b/src/Clay/Comments.hs
@@ -1,13 +1,8 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 module Clay.Comments where
 
-#if __GLASGOW_HASKELL__ < 808
-import Data.Foldable (foldMap)
-import Data.Monoid ((<>))
-#endif
 import Data.Maybe (isNothing)
 import Data.List (partition)
 

--- a/src/Clay/Comments.hs
+++ b/src/Clay/Comments.hs
@@ -1,10 +1,13 @@
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Clay.Comments where
 
+#if __GLASGOW_HASKELL__ < 808
 import Data.Foldable (foldMap)
 import Data.Monoid ((<>))
+#endif
 import Data.Maybe (isNothing)
 import Data.List (partition)
 

--- a/src/Clay/Common.hs
+++ b/src/Clay/Common.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
 
 -- | A bunch of type classes representing common values shared between multiple
 -- CSS properties, like `Auto`, `Inherit`, `None`, `Normal` and several more.
@@ -11,7 +11,9 @@ module Clay.Common where
 
 import Clay.Property
 import Data.String (IsString)
+#if __GLASGOW_HASKELL__ < 808
 import Data.Monoid (Monoid, (<>))
+#endif
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Common.hs
+++ b/src/Clay/Common.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 -- | A bunch of type classes representing common values shared between multiple
 -- CSS properties, like `Auto`, `Inherit`, `None`, `Normal` and several more.
@@ -11,9 +11,6 @@ module Clay.Common where
 
 import Clay.Property
 import Data.String (IsString)
-#if __GLASGOW_HASKELL__ < 808
-import Data.Monoid (Monoid, (<>))
-#endif
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Display.hs
+++ b/src/Clay/Display.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.Display
 (
 -- * Float.
@@ -81,7 +81,9 @@ module Clay.Display
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Data.String
 
 import Clay.Size

--- a/src/Clay/Display.hs
+++ b/src/Clay/Display.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.Display
 (
 -- * Float.
@@ -81,9 +81,6 @@ module Clay.Display
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Data.String
 
 import Clay.Size

--- a/src/Clay/FontFace.hs
+++ b/src/Clay/FontFace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Clay.FontFace
   ( FontFaceFormat (..)
   , FontFaceSrc (..)
@@ -9,10 +9,6 @@ import Clay.Common (call)
 import Clay.Property (Prefixed (Plain), Value(Value), Val (value), quote)
 import Clay.Stylesheet (Css, key)
 
-#if __GLASGOW_HASKELL__ < 808
-import Data.Monoid ((<>))
-import Data.Functor ((<$>))
-#endif
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 

--- a/src/Clay/FontFace.hs
+++ b/src/Clay/FontFace.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
 module Clay.FontFace
   ( FontFaceFormat (..)
   , FontFaceSrc (..)
@@ -9,8 +9,10 @@ import Clay.Common (call)
 import Clay.Property (Prefixed (Plain), Value(Value), Val (value), quote)
 import Clay.Stylesheet (Css, key)
 
+#if __GLASGOW_HASKELL__ < 808
 import Data.Monoid ((<>))
 import Data.Functor ((<$>))
+#endif
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 

--- a/src/Clay/Gradient.hs
+++ b/src/Clay/Gradient.hs
@@ -2,6 +2,7 @@
     OverloadedStrings
   , FlexibleInstances
   , GeneralizedNewtypeDeriving
+  , CPP
   #-}
 module Clay.Gradient
 (
@@ -36,7 +37,9 @@ module Clay.Gradient
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 
 import Clay.Color
 import Clay.Common

--- a/src/Clay/Gradient.hs
+++ b/src/Clay/Gradient.hs
@@ -2,7 +2,6 @@
     OverloadedStrings
   , FlexibleInstances
   , GeneralizedNewtypeDeriving
-  , CPP
   #-}
 module Clay.Gradient
 (
@@ -36,10 +35,6 @@ module Clay.Gradient
 
 )
 where
-
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 
 import Clay.Color
 import Clay.Common

--- a/src/Clay/List.hs
+++ b/src/Clay/List.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.List
 ( ListStyleType
 , listStyleType
@@ -36,9 +36,6 @@ module Clay.List
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 import Data.Text (Text)
 
 import Clay.Common

--- a/src/Clay/List.hs
+++ b/src/Clay/List.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.List
 ( ListStyleType
 , listStyleType
@@ -36,7 +36,9 @@ module Clay.List
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
+#endif
 import Data.Text (Text)
 
 import Clay.Common

--- a/src/Clay/Mask.hs
+++ b/src/Clay/Mask.hs
@@ -2,6 +2,7 @@
     OverloadedStrings
   , FlexibleInstances
   , GeneralizedNewtypeDeriving
+  , CPP
   #-}
 module Clay.Mask
 (
@@ -57,7 +58,9 @@ module Clay.Mask
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
+#endif
 
 import Clay.Background
 import Clay.Common

--- a/src/Clay/Mask.hs
+++ b/src/Clay/Mask.hs
@@ -2,7 +2,6 @@
     OverloadedStrings
   , FlexibleInstances
   , GeneralizedNewtypeDeriving
-  , CPP
   #-}
 module Clay.Mask
 (
@@ -57,10 +56,6 @@ module Clay.Mask
 
 )
 where
-
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 
 import Clay.Background
 import Clay.Common

--- a/src/Clay/Property.hs
+++ b/src/Clay/Property.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.Property where
 
 import Control.Arrow (second)
@@ -6,7 +6,9 @@ import Data.Fixed (Fixed, HasResolution (resolution), showFixed)
 import Data.List (partition, sort)
 import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Maybe
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
+#endif
 import Data.String
 import Data.Text (Text, replace)
 

--- a/src/Clay/Property.hs
+++ b/src/Clay/Property.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.Property where
 
 import Control.Arrow (second)
@@ -6,9 +6,6 @@ import Data.Fixed (Fixed, HasResolution (resolution), showFixed)
 import Data.List (partition, sort)
 import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Maybe
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 import Data.String
 import Data.Text (Text, replace)
 

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings, CPP #-}
 module Clay.Render
 ( Config (..)
 , pretty
@@ -14,7 +14,9 @@ where
 
 import           Control.Applicative
 import           Control.Monad.Writer
+#if __GLASGOW_HASKELL__ < 808
 import           Data.Foldable          (foldMap)
+#endif
 import           Data.List              (sort)
 import           Data.Maybe
 import           Data.Text              (Text, pack)

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Clay.Render
 ( Config (..)
 , pretty
@@ -14,9 +14,6 @@ where
 
 import           Control.Applicative
 import           Control.Monad.Writer
-#if __GLASGOW_HASKELL__ < 808
-import           Data.Foldable          (foldMap)
-#endif
 import           Data.List              (sort)
 import           Data.Maybe
 import           Data.Text              (Text, pack)

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -6,10 +6,13 @@
   , UndecidableInstances
   , ViewPatterns
   , PatternGuards
+  , CPP
   #-}
 module Clay.Selector where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Semigroup
+#endif
 import Data.String
 import Data.Text (Text)
 

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -6,13 +6,9 @@
   , UndecidableInstances
   , ViewPatterns
   , PatternGuards
-  , CPP
   #-}
 module Clay.Selector where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Semigroup
-#endif
 import Data.String
 import Data.Text (Text)
 

--- a/src/Clay/Selector.hs
+++ b/src/Clay/Selector.hs
@@ -9,7 +9,6 @@
   #-}
 module Clay.Selector where
 
-import Control.Applicative
 import Data.Semigroup
 import Data.String
 import Data.Text (Text)

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -2,18 +2,12 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE CPP #-}
 module Clay.Stylesheet where
 
 import Control.Applicative
 import Control.Arrow (second)
 import Control.Monad.Writer (Writer, execWriter, tell)
 import Data.Maybe (isJust)
-#if __GLASGOW_HASKELL__ < 808
-import Data.Monoid (Monoid(..))
-import Data.Semigroup (Semigroup(..))
-import Data.Foldable (foldMap)
-#endif
 import Data.String (IsString)
 import Data.Text (Text)
 

--- a/src/Clay/Stylesheet.hs
+++ b/src/Clay/Stylesheet.hs
@@ -2,15 +2,18 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE CPP #-}
 module Clay.Stylesheet where
 
 import Control.Applicative
 import Control.Arrow (second)
 import Control.Monad.Writer (Writer, execWriter, tell)
-import Data.Foldable (foldMap)
 import Data.Maybe (isJust)
+#if __GLASGOW_HASKELL__ < 808
 import Data.Monoid (Monoid(..))
 import Data.Semigroup (Semigroup(..))
+import Data.Foldable (foldMap)
+#endif
 import Data.String (IsString)
 import Data.Text (Text)
 

--- a/src/Clay/Text.hs
+++ b/src/Clay/Text.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.Text
 (
 -- * Letter and word-spacing.
@@ -94,7 +94,9 @@ module Clay.Text
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Data.String
 import Data.Text (Text)
 

--- a/src/Clay/Text.hs
+++ b/src/Clay/Text.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.Text
 (
 -- * Letter and word-spacing.
@@ -94,9 +94,6 @@ module Clay.Text
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Data.String
 import Data.Text (Text)
 

--- a/src/Clay/Time.hs
+++ b/src/Clay/Time.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.Time
 (
 
@@ -12,9 +12,6 @@ module Clay.Time
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Data.Text (pack)
 
 import Clay.Common

--- a/src/Clay/Time.hs
+++ b/src/Clay/Time.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.Time
 (
 
@@ -12,7 +12,9 @@ module Clay.Time
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Data.Text (pack)
 
 import Clay.Common

--- a/src/Clay/Transform.hs
+++ b/src/Clay/Transform.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
 module Clay.Transform
 (
 
@@ -39,7 +39,9 @@ module Clay.Transform
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Prelude hiding (Left, Right)
 
 import Clay.Property

--- a/src/Clay/Transform.hs
+++ b/src/Clay/Transform.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving, CPP #-}
+{-# LANGUAGE OverloadedStrings, GeneralizedNewtypeDeriving #-}
 module Clay.Transform
 (
 
@@ -39,9 +39,6 @@ module Clay.Transform
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Prelude hiding (Left, Right)
 
 import Clay.Property

--- a/src/Clay/Transition.hs
+++ b/src/Clay/Transition.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE
     OverloadedStrings
   , GeneralizedNewtypeDeriving
-  , CPP
   #-}
 module Clay.Transition
 (
@@ -37,9 +36,6 @@ module Clay.Transition
 )
 where
 
-#if __GLASGOW_HASKELL__ < 804
-import Data.Monoid
-#endif
 import Data.Text (Text)
 
 import Clay.Common

--- a/src/Clay/Transition.hs
+++ b/src/Clay/Transition.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE
     OverloadedStrings
   , GeneralizedNewtypeDeriving
+  , CPP
   #-}
 module Clay.Transition
 (
@@ -36,7 +37,9 @@ module Clay.Transition
 )
 where
 
+#if __GLASGOW_HASKELL__ < 804
 import Data.Monoid
+#endif
 import Data.Text (Text)
 
 import Clay.Common


### PR DESCRIPTION
This PR addresses #190. A few of the imports were actually unused, and have been removed. For the remaining imports, we now wrap them with CPP macros. **GHC 8.4.x** and later will now ignore these imports, avoiding the build noise. For **GHC 8.8.x**, any imports from `Monoid`, `Semigroup`, `Functor` and `Foldable` that were throwing warnings are now guarded by CPP macros.  I have tested these changes on **GHC 8.2.2**, **8.4.1**, **8.4.4**, **8.6.5** and **8.8.1**.