### PR TITLE
Add size constants and properties for grid areas

### DIFF
--- a/clay.cabal
+++ b/clay.cabal
@@ -57,6 +57,7 @@ Library
     Clay.FontFace
     Clay.Geometry
     Clay.Gradient
+    Clay.Grid 
     Clay.List
     Clay.Media
     Clay.Mask

--- a/shell.nix
+++ b/shell.nix
@@ -6,6 +6,5 @@ in release.pkgs.stdenv.lib.overrideDerivation release.clay.env (oldAttrs: rec {
   nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [
     release.cabal
     release.pkgs.haskellPackages.cabal2nix
-    release.pkgs.haskellPackages.ghcid
   ];
 })

--- a/shell.nix
+++ b/shell.nix
@@ -6,5 +6,6 @@ in release.pkgs.stdenv.lib.overrideDerivation release.clay.env (oldAttrs: rec {
   nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [
     release.cabal
     release.pkgs.haskellPackages.cabal2nix
+    release.pkgs.haskellPackages.ghcid
   ];
 })

--- a/src/Clay.hs
+++ b/src/Clay.hs
@@ -112,6 +112,7 @@ module Clay
 , module Clay.FontFace
 , module Clay.Geometry
 , module Clay.Gradient
+, module Clay.Grid
 , module Clay.List
 , module Clay.Text
 , module Clay.Transform
@@ -155,6 +156,7 @@ import Clay.Font       hiding (menu, caption, small, icon)
 import Clay.FontFace
 import Clay.Geometry
 import Clay.Gradient
+import Clay.Grid
 import Clay.List
 import Clay.Size
 import Clay.Text       hiding (pre)
@@ -182,6 +184,6 @@ import Clay.Filter     hiding (url, opacity)
 -- grouped with the preceding value when rendered compactly.
 --
 -- Note that /every/ generated line in the generated content will feature the
--- comment. 
+-- comment.
 --
 -- An empty comment generates '@/*  */@'.

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -1,4 +1,44 @@
 {-# LANGUAGE OverloadedStrings #-}
+-- | Partial implementation of <https://alligator.io/css/css-grid-layout-grid-areas grid area CSS API>.
+--
+-- For instance, you want to generate the following CSS:
+--
+-- @
+-- .grid1 {
+--   display: grid;
+--   width: max-content;
+-- }
+--
+-- .grid3 {
+--   display: grid;
+--   width: max-content;
+-- }
+--
+-- \@media (min-width: 40.0rem) {
+--   .grid3 {
+--     display: grid;
+--     grid-template-columns: 1fr 1fr 1fr;
+--     grid-gap: 1rem;
+--     width: max-content;
+--   }
+-- }
+-- @
+--
+-- The corresponding clay code:
+--
+-- @
+--  ".grid1" ? do
+--    display grid
+--    width maxContent
+--  ".grid3" ? do
+--    display grid
+--    width maxContent
+--  query M.screen [M.minWidth (rem 40)] $ ".grid3" ? do
+--    display grid
+--    gridTemplateColumns [fr 1, fr 1, fr 1]
+--    gridGap $ rem 1
+--    width maxContent
+-- @
 module Clay.Grid
 ( gridGap
 , gridTemplateColumns

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Clay.Grid
+( gridGap
+, gridTemplateColumns
+)
+where
+
+import Clay.Property
+import Clay.Size
+import Clay.Stylesheet
+
+-- | Property sets the gaps (gutters) between rows and columns.
+gridGap :: Size a -> Css
+gridGap = key "grid-gap"
+
+-- | Property defines the line names and track sizing functions of the grid columns.
+gridTemplateColumns :: [Size a] -> Css
+gridTemplateColumns = key "grid-template-columns" . noCommas

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -33,6 +33,10 @@ module Clay.Size
 , vh
 , vmin
 , vmax
+, maxContent
+, minContent
+, available
+, fitContent
 
 -- * Calculation operators for calc
 
@@ -164,6 +168,22 @@ vmin i = SimpleSize (cssDoubleText i <> "vmin")
 
 -- | SimpleSize in vmax's (the larger of vw or vh).
 vmax i = SimpleSize (cssDoubleText i <> "vmax")
+
+-- | SimpleSize for the intrinsic preferred width.
+maxContent :: Size LengthUnit
+maxContent = SimpleSize "max-content"
+
+-- | SimpleSize for the intrinsic minimum width.
+minContent :: Size LengthUnit
+minContent = SimpleSize "min-content"
+
+-- | SimpleSize for The containing block width minus horizontal margin, border, and padding.
+available :: Size LengthUnit
+available = SimpleSize "available"
+
+-- | The larger of the intrinsic minimum width or the smaller of the intrinsic preferred width and the available width
+fitContent :: Size LengthUnit
+fitContent = SimpleSize "fit-content"
 
 -- | SimpleSize in percents.
 pct :: Double -> Size Percentage

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -33,6 +33,7 @@ module Clay.Size
 , vh
 , vmin
 , vmax
+, fr
 , maxContent
 , minContent
 , available
@@ -146,7 +147,7 @@ pt i = SimpleSize (cssDoubleText i <> "pt")
 -- | Size in picas (1pc = 12pt).
 pc i = SimpleSize (cssDoubleText i <> "pc")
 
-em, ex, rem, vw, vh, vmin, vmax :: Double -> Size LengthUnit
+em, ex, rem, vw, vh, vmin, vmax, fr :: Double -> Size LengthUnit
 
 -- | Size in em's (computed cssDoubleText of the font-size).
 em i = SimpleSize (cssDoubleText i <> "em")
@@ -168,6 +169,9 @@ vmin i = SimpleSize (cssDoubleText i <> "vmin")
 
 -- | SimpleSize in vmax's (the larger of vw or vh).
 vmax i = SimpleSize (cssDoubleText i <> "vmax")
+
+-- | SimpleSize in fr's (a fractional unit and 1fr is for 1 part of the available space in grid areas).
+fr i = SimpleSize (cssDoubleText i <> "fr")
 
 -- | SimpleSize for the intrinsic preferred width.
 maxContent :: Size LengthUnit


### PR DESCRIPTION
Hi, I hit missing properties for sizes and grid areas and added them into my project. So, that it is draft for possible additions. I am not sure if experimental CSS API is acceptable in clay. Also, more consistent part of grid areas API should be added to the PR.

Use case:
``` CSS
.grid1 {
  display: grid;
  width: max-content;
}

.grid3 {
  display: grid;
  width: max-content;
}

@media (min-width: 40.0rem) {
  .grid3 {
    display: grid;
    grid-template-columns: 1fr 1fr 1fr;
    grid-gap: 1rem;
    width: max-content;
  }
}

```
``` haskell
  ".grid1" ? do
    display grid
    width maxContent
  ".grid3" ? do
    display grid
    width maxContent
  query M.screen [M.minWidth (rem 40)] $ ".grid3" ? do
    display grid
    gridTemplateColumns [fr 1, fr 1, fr 1]
    gridGap $ rem 1
    width maxContent
```