### PR TITLE
Fixed example

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -54,12 +54,12 @@ main = putCss logo
          before &
            do toTheRight m
               transforms [translate (px 0) (px (div m 2)), skew (deg 0) (deg 45)]
-              boxShadow 0 0 (px 40) black
+              boxShadow' 0 0 (px 40) black
 
          after &
            do toTheBottom m
               transforms [translate (px (div m 2)) (px 0), skew (deg 45) (deg 0)]
-              boxShadow 0 0 (px 40) black
+              boxShadow' 0 0 (px 40) black
 
          "div" <?
            do position absolute
@@ -71,7 +71,7 @@ main = putCss logo
     squareI i x y c = ".square" `with` nthChild i ?
       do rectangular x y s s
          background (hGradient (c -. 100) c)
-         boxShadow 0 0 (px 50) c
+         boxShadow' 0 0 (px 50) c
          before & background (vGradient (c -. 10) (c -. 60))
          after  & background (hGradient (c +. 10) (c +. 80))
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -35,10 +35,10 @@ main = putCss logo
          forM_ [0..3] $ \x ->
            forM_ [0..3] $ \y ->
              do let idx = (pack . show) (1 + y * 4 + x)
-                    clr = cycle cs !! floor y
-                squareI idx (m * y + x * (s + m))
-                            (m * x + y * (s + m))
-                            (clr -. 50 +. floor (x * 50))
+                    clr = cycle cs !! y
+                squareI idx (m * fromIntegral y + fromIntegral x * (s + m))
+                            (m * fromIntegral x + fromIntegral y * (s + m))
+                            (clr -. 50 +. fromIntegral (x * 50))
 
     square = ".square" ?
       do font ( Optional (Just bold) Nothing (Just italic)

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+-- OverloadedLists here causes things like forM_ [0..3] cause type ambiguity
 module Main where
 
 import Control.Monad
 import Data.Text (pack)
+import Data.List.NonEmpty (fromList)
 import Prelude
 import Clay hiding (i, s, div)
 import Clay.Selector (with)
@@ -54,12 +56,12 @@ main = putCss logo
          before &
            do toTheRight m
               transforms [translate (px 0) (px $ fromIntegral $ div (floor m) 2), skew (deg 0) (deg 45)]
-              boxShadow' 0 0 (px 40) black
+              boxShadow $ fromList [black `bsColor` shadowWithBlur 0 0 (px 40)]
 
          after &
            do toTheBottom m
               transforms [translate (px $ fromIntegral $ div (floor m) 2) (px 0), skew (deg 45) (deg 0)]
-              boxShadow' 0 0 (px 40) black
+              boxShadow $ fromList [black `bsColor` shadowWithBlur 0 0 (px 40)]
 
          "div" <?
            do position absolute
@@ -71,7 +73,7 @@ main = putCss logo
     squareI i x y c = ".square" `with` nthChild i ?
       do rectangular x y s s
          background (hGradient (c -. 100) c)
-         boxShadow' 0 0 (px 50) c
+         boxShadow $ fromList [c `bsColor` shadowWithBlur 0 0 (px 50)]
          before & background (vGradient (c -. 10) (c -. 60))
          after  & background (hGradient (c +. 10) (c +. 80))
 

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -11,8 +11,8 @@ main :: IO ()
 main = putCss logo
 
   where
-    s = 80
-    m = 30
+    s = 80 :: Double
+    m = 30 :: Double
     cs = [ "#78e700"
          , "#00b454"
          , "#ff3900"
@@ -33,10 +33,10 @@ main = putCss logo
          forM_ [0..3] $ \x ->
            forM_ [0..3] $ \y ->
              do let idx = (pack . show) (1 + y * 4 + x)
-                    clr = cycle cs !! fromInteger y
+                    clr = cycle cs !! floor y
                 squareI idx (m * y + x * (s + m))
                             (m * x + y * (s + m))
-                            (clr -. 50 +. (x * 50))
+                            (clr -. 50 +. floor (x * 50))
 
     square = ".square" ?
       do font ( Optional (Just bold) Nothing (Just italic)
@@ -53,12 +53,12 @@ main = putCss logo
 
          before &
            do toTheRight m
-              transforms [translate (px 0) (px (div m 2)), skew (deg 0) (deg 45)]
+              transforms [translate (px 0) (px $ fromIntegral $ div (floor m) 2), skew (deg 0) (deg 45)]
               boxShadow' 0 0 (px 40) black
 
          after &
            do toTheBottom m
-              transforms [translate (px (div m 2)) (px 0), skew (deg 45) (deg 0)]
+              transforms [translate (px $ fromIntegral $ div (floor m) 2) (px 0), skew (deg 45) (deg 0)]
               boxShadow' 0 0 (px 40) black
 
          "div" <?
@@ -66,7 +66,7 @@ main = putCss logo
               background (vGradient (setA 0 white) (setA 60 white))
               borderBottomLeftRadius  (pct 100) (pct 100)
               borderBottomRightRadius (pct  40) (pct  15)
-              [left, top, right, bottom] `forM_` ($ 4)
+              [left, top, right, bottom] `forM_` ($ pct 4)
 
     squareI i x y c = ".square" `with` nthChild i ?
       do rectangular x y s s

--- a/examples/generate.sh
+++ b/examples/generate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-runhaskell -i../../src Main > new.css &&
+runhaskell -i../src Main > new.css &&
   mv new.css style.css &&
   echo "done" ||
   echo "failed"

--- a/src/Clay/Box.hs
+++ b/src/Clay/Box.hs
@@ -81,6 +81,10 @@ newtype BoxShadow = BoxShadow Value
 -- > boxShadow . pure $ shadow (px 1) (px 1)
 --
 -- Use with @{-# LANGUAGE OverloadedLists #-}@ for the simplest list syntax.
+-- Note that sometimes when @{-# LANGUAGE OverloadedLists #-}@ is active, GHC
+-- has troubles identifying what type the list should be converted to. Examples:
+-- 1) "forM_ [0..10] $ \x -> ..."
+-- 2) "[left, top, right, bottom] `forM_` ($ pct 4)"
 --
 -- > boxShadow [none]
 -- > boxShadow [shadow (px 1) (px 1)]

--- a/src/Clay/Color.hs
+++ b/src/Clay/Color.hs
@@ -118,14 +118,17 @@ toHsla color =
 (*.) :: Color -> Integer -> Color
 (*.) (Rgba r g b a) i = Rgba (clamp (r * i)) (clamp (g * i)) (clamp (b * i)) a
 (*.) o              _ = o
+infixl 7 *.
 
 (+.) :: Color -> Integer -> Color
 (+.) (Rgba r g b a) i = Rgba (clamp (r + i)) (clamp (g + i)) (clamp (b + i)) a
 (+.) o              _ = o
+infixl 6 +.
 
 (-.) :: Color -> Integer -> Color
 (-.) (Rgba r g b a) i = Rgba (clamp (r - i)) (clamp (g - i)) (clamp (b - i)) a
 (-.) o              _ = o
+infixl 6 -.
 
 clamp :: Ord a => Num a => a -> a
 clamp i = max (min i (fromIntegral (255 :: Integer))) (fromIntegral (0 :: Integer))


### PR DESCRIPTION
This closes #194.
Commit messages are self-explanatory. 2 things that are questionable are:
1) The way `Double`s are handled. Another option would be to make `s` and `m` of type `Integer`, but then other places would need to be fixed.
2) Usage of `fromList` instead of `OverloadedLists` option. The comment on top mentions the issue. If `OverloadedLists` is used, types in constructs like `forM_ [0..3] do ...` would need to be specified explicitly, which is not worth it in this example, since such constructs are used a lot.
The code has been tested on GHC 8.4.4, 8.6.5 and 8.8.1. Nix was not used for building, because I am not very familiar with it, and the example seems to not be included in .nix configuration files.