### PR TITLE
Add -webkit- prefix to sticky position attribute

### DIFF
--- a/spec/Clay/PositionSpec.hs
+++ b/spec/Clay/PositionSpec.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE OverloadedStrings, OverloadedLists #-}
+module Clay.PositionSpec where
+
+import Test.Hspec
+import Clay
+import Common
+
+spec :: Spec
+spec = do
+  describe "position (Mozilla examples)" $ do
+    describe "static" $ do
+      "{position:static}" `shouldRenderAsFrom`
+        "{position:static}" $
+          position static
+    describe "absolute" $ do
+      "{position:absolute}" `shouldRenderAsFrom`
+        "{position:absolute}" $
+          position absolute
+    describe "fixed" $ do
+      "{position:fixed}" `shouldRenderAsFrom`
+        "{position:fixed}" $
+          position fixed
+    describe "sticky" $ do
+      "{position:sticky}" `shouldRenderAsFrom`
+        "{position:-webkit-sticky;position:sticky}" $
+          position sticky

--- a/src/Clay/Common.hs
+++ b/src/Clay/Common.hs
@@ -9,6 +9,7 @@
 
 module Clay.Common where
 
+import Data.Text (Text)
 import Clay.Property
 import Data.String (IsString)
 
@@ -73,13 +74,25 @@ instance Unset    Value where unset    = unsetValue
 -- | Common list browser prefixes to make experimental properties work in
 -- different browsers.
 
+webkitPrefix :: (Text, Text)
+webkitPrefix = ( "-webkit-", "" )
+
+emptyPrefix :: (Text, Text)
+emptyPrefix = ( "", "" )
+
+webkit :: Prefixed
+webkit = Prefixed $
+  [ webkitPrefix
+  , emptyPrefix
+  ]
+
 browsers :: Prefixed
-browsers = Prefixed
-  [ ( "-webkit-", "" )
-  , (    "-moz-", "" )
-  , (     "-ms-", "" )
-  , (      "-o-", "" )
-  , (         "", "" )
+browsers = Prefixed $
+  [ webkitPrefix
+  , ( "-moz-", "" )
+  , (  "-ms-", "" )
+  , (   "-o-", "" )
+  , emptyPrefix
   ]
 
 -------------------------------------------------------------------------------

--- a/src/Clay/Display.hs
+++ b/src/Clay/Display.hs
@@ -127,7 +127,7 @@ static   = Position "static"
 absolute = Position "absolute"
 fixed    = Position "fixed"
 relative = Position "relative"
-sticky = Position "sticky"
+sticky = Position $ Value (webkit <> Plain "sticky")
 
 position :: Position -> Css
 position = key "position"


### PR DESCRIPTION
As detailed in https://caniuse.com/#feat=css-sticky,
Apple browsers require the -webkit- prefix to render the
sticky attribute.

This PR causes the attribute to render as:

```
position: -webkit-sticky;
position: sticky;
```

closes https://github.com/sebastiaanvisser/clay/issues/202