### PR TITLE
Grid Support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -23,11 +23,9 @@ CHANGELOG
       remove `available`, `normal`: not valid css sizes
       include `initial`, `unset` keyword values
       upgrade `fitContent` from value to function, it's not valid without an argument:
+         https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content-length-percentage
       minContent & maxContent are now type class overloaded values
-        https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content-length-percentage
-
-      drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at nearly 98% for unprefixed calc)
-
+  
   0.13.3:
     - Improve README
     - Relax types for `sym2` and `sym3` combinators

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ CHANGELOG
         gridTemplateColumns: `grid-template-columns`
         gridTemplateAreas: `grid-template-areas`
         gridArea: `grid-area`
+      deprecate: 'Clay.Grid.gridGap' in favor of 'Clay.Grid.gap'
       newtype GridArea for type safe grid area templating
 
   0.14.0:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 CHANGELOG
 
-  0.15.0:
+  0.14.0:
+    - Drop support for GHC 8.2
+    - Added `text-align-last`
+    - Fix typo in `stepsStart`
+    Thanks to Vasiliy Yorkin and Florian Grignon.
     - 'Clay.Grid':
       new properties:
         gap: `gap` & `grid-gap`
@@ -11,12 +15,10 @@ CHANGELOG
         gridAutoColumns: `grid-auto-columns`
         gridAutoFlow: `grid-auto-flow`
         gridTemplateRows: `grid-template-rows`
-        gridTemplateColumns: `grid-template-columns` (already existed, but now handles more cases)
+        gridTemplateColumns: `grid-template-columns`
         gridTemplateAreas: `grid-template-areas`
-      deprecate: 'Clay.Grid.gridGap' in favor of 'Clay.Grid.gap'
     - 'Clay.Size':
       AnyUnit, a size parameter for lists of mixed units
-      upcast :: Size a -> Size AnyUnit
       minmax :: Size a -> Size a -> Size AnyUnit
       remove `available`, `normal`: not valid css sizes
       include `initial`, `unset` keyword values
@@ -25,12 +27,6 @@ CHANGELOG
         https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content-length-percentage
 
       drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at nearly 98% for unprefixed calc)
-
-  0.14.0:
-    - Drop support for GHC 8.2
-    - Added `text-align-last`
-    - Fix typo in `stepsStart`
-    Thanks to Vasiliy Yorkin and Florian Grignon.
 
   0.13.3:
     - Improve README

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,16 +6,21 @@ CHANGELOG
         gap: `gap` & `grid-gap`
         rowGap: `row-gap` & `grid-row-gap`
         columnGap: `column-gap` & `grid-column-gap`
-        gridTemplateRows: `grid-template-rows`
-        gridTemplateColumns: `grid-template-columns`
-        gridTemplateAreas: `grid-template-areas`
         gridArea: `grid-area`
+        gridAutoRows: `grid-auto-rows`
+        gridAutoColumns: `grid-auto-columns`
+        gridTemplateRows: `grid-template-rows`
+        gridTemplateColumns: `grid-template-columns` (already existed, but now handles more cases)
+        gridTemplateAreas: `grid-template-areas`
       deprecate: 'Clay.Grid.gridGap' in favor of 'Clay.Grid.gap'
-      newtype GridArea for type safe grid area templating
     - 'Clay.Size':
       AnyUnit, a size parameter for lists of mixed units
       upcast :: Size a -> Size AnyUnit
-      minmax :: Size a -> Size a -> Size AnyUnit, a css function for grids
+      minmax :: Size a -> Size a -> Size AnyUnit
+      remove `available`, it's not a valid css size
+      upgrade `fitContent` from value to function, it's not valid without an argument:
+        https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content-length-percentage
+
       drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at nearly 98% for unprefixed calc)
 
   0.14.0:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,17 @@
 CHANGELOG
 
+  0.15.0:
+    - 'Clay.Grid':
+      new properties:
+        gap: `gap` & `grid-gap`
+        rowGap: `row-gap` & `grid-row-gap`
+        columnGap: `column-gap` & `grid-column-gap`
+        gridTemplateRows: `grid-template-rows`
+        gridTemplateColumns: `grid-template-columns`
+        gridTemplateAreas: `grid-template-areas`
+        gridArea: `grid-area`
+      newtype GridArea for type safe grid area templating
+
   0.14.0:
     - Drop support for GHC 8.2
     - Added `text-align-last`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ CHANGELOG
         gridArea: `grid-area`
         gridAutoRows: `grid-auto-rows`
         gridAutoColumns: `grid-auto-columns`
+        gridAutoFlow: `grid-auto-flow`
         gridTemplateRows: `grid-template-rows`
         gridTemplateColumns: `grid-template-columns` (already existed, but now handles more cases)
         gridTemplateAreas: `grid-template-areas`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,7 @@ CHANGELOG
       minmax :: Size a -> Size a -> Size AnyUnit
       remove `available`, it's not a valid css size
       upgrade `fitContent` from value to function, it's not valid without an argument:
+      minContent & maxContent are now type class overloaded values
         https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content-length-percentage
 
       drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at nearly 98% for unprefixed calc)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ CHANGELOG
     - 'Clay.Size':
       AnyUnit, a size parameter for lists of mixed units
       upcast :: Size a -> Size AnyUnit
+      minmax :: Size a -> Size a -> Size AnyUnit, a css function for grids
       drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at nearly 98% for unprefixed calc)
 
   0.14.0:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,8 @@ CHANGELOG
       AnyUnit, a size parameter for lists of mixed units
       upcast :: Size a -> Size AnyUnit
       minmax :: Size a -> Size a -> Size AnyUnit
-      remove `available`, it's not a valid css size
+      remove `available`, `normal`: not valid css sizes
+      include `initial`, `unset` keyword values
       upgrade `fitContent` from value to function, it's not valid without an argument:
       minContent & maxContent are now type class overloaded values
         https://drafts.csswg.org/css-sizing-3/#valdef-width-fit-content-length-percentage

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,10 @@ CHANGELOG
         gridArea: `grid-area`
       deprecate: 'Clay.Grid.gridGap' in favor of 'Clay.Grid.gap'
       newtype GridArea for type safe grid area templating
+    - 'Clay.Size':
+      AnyUnit, a size parameter for lists of mixed units
+      upcast :: Size a -> Size AnyUnit
+      drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at 96% for unprefixed calc)
 
   0.14.0:
     - Drop support for GHC 8.2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,7 +15,7 @@ CHANGELOG
     - 'Clay.Size':
       AnyUnit, a size parameter for lists of mixed units
       upcast :: Size a -> Size AnyUnit
-      drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at 96% for unprefixed calc)
+      drop browser prefixes from `calc` ((caniuse)[https://caniuse.com/#feat=calc] is at nearly 98% for unprefixed calc)
 
   0.14.0:
     - Drop support for GHC 8.2

--- a/clay.cabal
+++ b/clay.cabal
@@ -76,7 +76,7 @@ Library
     base  >= 4.11 && < 5,
     mtl   >= 1    && < 2.3,
     text  >= 0.11 && < 1.3,
-    these
+    these < 1.2
   GHC-Options: -Wall -Wcompat
 
 Test-Suite Test-Clay
@@ -88,7 +88,7 @@ Test-Suite Test-Clay
     base                 >= 4.11  && < 5,
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
-    these,
+    these                < 1.2,
     hspec                >= 2.2.0 && < 2.8,
     hspec-discover       >= 2.2.0 && < 2.8
   GHC-Options: -Wall -Wcompat

--- a/clay.cabal
+++ b/clay.cabal
@@ -57,7 +57,7 @@ Library
     Clay.FontFace
     Clay.Geometry
     Clay.Gradient
-    Clay.Grid 
+    Clay.Grid
     Clay.List
     Clay.Media
     Clay.Mask
@@ -88,5 +88,6 @@ Test-Suite Test-Clay
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
     hspec                >= 2.2.0 && < 2.8,
-    hspec-discover       >= 2.2.0 && < 2.8
+    hspec-discover       >= 2.2.0 && < 2.8,
+    deep-seq             >= 1.2.0 && < 1.5
   GHC-Options: -Wall -Wcompat

--- a/clay.cabal
+++ b/clay.cabal
@@ -88,6 +88,5 @@ Test-Suite Test-Clay
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
     hspec                >= 2.2.0 && < 2.8,
-    hspec-discover       >= 2.2.0 && < 2.8,
-    deep-seq             >= 1.2.0 && < 1.5
+    hspec-discover       >= 2.2.0 && < 2.8
   GHC-Options: -Wall -Wcompat

--- a/clay.cabal
+++ b/clay.cabal
@@ -76,7 +76,7 @@ Library
     base  >= 4.11 && < 5,
     mtl   >= 1    && < 2.3,
     text  >= 0.11 && < 1.3,
-    these >= 0.2   && < 1.2,
+    these >= 0.2   && < 1.2
   GHC-Options: -Wall -Wcompat
 
 Test-Suite Test-Clay

--- a/clay.cabal
+++ b/clay.cabal
@@ -76,7 +76,7 @@ Library
     base  >= 4.11 && < 5,
     mtl   >= 1    && < 2.3,
     text  >= 0.11 && < 1.3,
-    these < 1.2
+    these >= 0.2   && < 1.2,
   GHC-Options: -Wall -Wcompat
 
 Test-Suite Test-Clay
@@ -88,7 +88,7 @@ Test-Suite Test-Clay
     base                 >= 4.11  && < 5,
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
-    these                < 1.2,
+    these                >= 0.2   && < 1.2,
     hspec                >= 2.2.0 && < 2.8,
     hspec-discover       >= 2.2.0 && < 2.8
   GHC-Options: -Wall -Wcompat

--- a/clay.cabal
+++ b/clay.cabal
@@ -75,7 +75,8 @@ Library
   Build-Depends:
     base  >= 4.11 && < 5,
     mtl   >= 1    && < 2.3,
-    text  >= 0.11 && < 1.3
+    text  >= 0.11 && < 1.3,
+    these
   GHC-Options: -Wall -Wcompat
 
 Test-Suite Test-Clay
@@ -87,6 +88,7 @@ Test-Suite Test-Clay
     base                 >= 4.11  && < 5,
     mtl                  >= 1     && < 2.3,
     text                 >= 0.11  && < 1.3,
+    these,
     hspec                >= 2.2.0 && < 2.8,
     hspec-discover       >= 2.2.0 && < 2.8
   GHC-Options: -Wall -Wcompat

--- a/nix/clay.nix
+++ b/nix/clay.nix
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 { mkDerivation, base, hspec, hspec-discover, mtl, stdenv, lib, text, these }:
 mkDerivation {
   pname = "clay";

--- a/nix/clay.nix
+++ b/nix/clay.nix
@@ -1,7 +1,7 @@
 { mkDerivation, base, hspec, hspec-discover, mtl, stdenv, lib, text }:
 mkDerivation {
   pname = "clay";
-  version = "0.14.0";
+  version = "0.15.0";
   src = ./..;
   libraryHaskellDepends = [ base mtl text ];
   testHaskellDepends = [ base hspec hspec-discover mtl text ];

--- a/nix/clay.nix
+++ b/nix/clay.nix
@@ -2,7 +2,7 @@
 { mkDerivation, base, hspec, hspec-discover, mtl, stdenv, lib, text, these }:
 mkDerivation {
   pname = "clay";
-  version = "0.15.0";
+  version = "0.14.0";
   src = ./..;
   libraryHaskellDepends = [ base mtl text these ];
   testHaskellDepends = [ base hspec hspec-discover mtl text these ];

--- a/nix/clay.nix
+++ b/nix/clay.nix
@@ -1,10 +1,11 @@
-{ mkDerivation, base, hspec, hspec-discover, mtl, stdenv, lib, text }:
+<<<<<<< HEAD
+{ mkDerivation, base, hspec, hspec-discover, mtl, stdenv, lib, text, these }:
 mkDerivation {
   pname = "clay";
   version = "0.15.0";
   src = ./..;
-  libraryHaskellDepends = [ base mtl text ];
-  testHaskellDepends = [ base hspec hspec-discover mtl text ];
+  libraryHaskellDepends = [ base mtl text these ];
+  testHaskellDepends = [ base hspec hspec-discover mtl text these ];
   homepage = "http://fvisser.nl/clay";
   description = "CSS preprocessor as embedded Haskell";
   license = lib.licenses.bsd3;

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -62,6 +62,27 @@ spec = do
         `shouldRenderFrom`
         gridAutoRows [upcast $ em 1, pct 20 @+@ fr 1, upcast $ auto]
 
+  describe "gridAutoFlow" $ do
+    "{grid-auto-flow:row}"
+      `shouldRenderFrom`
+      gridAutoFlow row
+
+    "{grid-auto-flow:column}"
+      `shouldRenderFrom`
+      gridAutoFlow column
+
+    "{grid-auto-flow:dense}"
+      `shouldRenderFrom`
+      gridAutoFlow dense
+
+    "{grid-auto-flow:row dense}"
+      `shouldRenderFrom`
+      gridAutoFlow rowDense
+
+    "{grid-auto-flow:column dense}"
+      `shouldRenderFrom`
+      gridAutoFlow columnDense
+
   describe "gridArea" $ do
     "{grid-area:header}"
       `shouldRenderFrom`

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -32,20 +32,35 @@ spec = do
         gridTemplateRows none
 
     describe "list of sizes" $ do
-      "{grid-template-rows:50px auto minmax(400em,50%)}"
+      "{grid-template-rows:50px fit-content(500px) minmax(400em,50%)}"
         `shouldRenderFrom`
-        gridTemplateRows [upcast (px 50), upcast auto, minmax (em 400) (pct 50)]
+        gridTemplateRows [upcast (px 50), upcast $ fitContent (px 500), minmax (em 400) (pct 50)]
 
   describe "gridTemplateColumns" $ do
     describe "keyword" $ do
-      "{grid-template-rows:none}"
+      "{grid-template-columns:none}"
         `shouldRenderFrom`
-        gridTemplateRows none
+        gridTemplateColumns none
 
     describe "list of sizes" $ do
       "{grid-template-columns:1em calc(20% + 1fr) auto}"
         `shouldRenderFrom`
         gridTemplateColumns [upcast $ em 1, pct 20 @+@ fr 1, upcast $ auto]
+
+  describe "gridAutoRows" $ do
+    describe "keywords" $ do
+      "{grid-auto-rows:min-content}"
+        `shouldRenderFrom`
+        gridAutoRows minContent
+
+      "{grid-auto-rows:max-content}"
+        `shouldRenderFrom`
+        gridAutoRows maxContent
+
+    describe "list of sizes" $ do
+      "{grid-auto-rows:1em calc(20% + 1fr) auto}"
+        `shouldRenderFrom`
+        gridAutoRows [upcast $ em 1, pct 20 @+@ fr 1, upcast $ auto]
 
   describe "gridArea" $ do
     "{grid-area:header}"

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -33,7 +33,7 @@ spec = do
       GridTemplateAreas_NotRectangular
         `shouldErrorFromRender`
         gridTemplateAreas
-          [ [ area_blank] -- length 1
+          [ [ area_blank]                 -- length 1
           , [ area_a, area_blank]         -- length 2
           , [ area_blank, area_b, area_c] -- length 3
           ]

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -146,7 +146,7 @@ spec = do
         area_c = "c"
         area_blank = blankGridArea
 
-      GridTemplateNamedAreas_NotRectangular
+      InvalidGridTemplateNotRectangular
         `shouldErrorFromRender`
         gridTemplateAreas
           [ [ area_blank]                 -- length 1
@@ -155,11 +155,11 @@ spec = do
           ]
 
     describe "empty template should error" $ do
-      GridTemplateNamedAreas_Empty
+      InvalidGridTemplateEmpty
         `shouldErrorFromRender`
         gridTemplateAreas []
 
     describe "template with empty row(s) should error" $ do
-      GridTemplateNamedAreas_EmptyRow
+      InvalidGridTemplateEmptyRow
         `shouldErrorFromRender`
         gridTemplateAreas [[], []]

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -32,9 +32,9 @@ spec = do
         gridTemplateRows none
 
     describe "list of sizes" $ do
-      "{grid-template-rows:1em auto min-content}"
+      "{grid-template-rows:50px auto 40em}"
         `shouldRenderFrom`
-        gridTemplateRows [SomeSize $ em 1, SomeSize auto, SomeSize minContent]
+        gridTemplateRows [px 50, auto, em 40]
 
   describe "gridTemplateColumns" $ do
     describe "keywords" $ do
@@ -43,9 +43,9 @@ spec = do
         gridTemplateRows none
 
     describe "list of sizes" $ do
-      "{grid-template-columns:1em 20% min-content}"
+      "{grid-template-columns:1em 20% auto}"
         `shouldRenderFrom`
-        gridTemplateColumns [SomeSize $ em 1, SomeSize $ pct 20, SomeSize minContent]
+        gridTemplateColumns [upcast $ em 1, pct 20 @+@ fr 1, upcast $ auto]
 
     describe "gridArea" $ do
       "{grid-area:header}"

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -43,7 +43,7 @@ spec = do
         gridTemplateRows none
 
     describe "list of sizes" $ do
-      "{grid-template-columns:1em 20% auto}"
+      "{grid-template-columns:1em calc(20% + 1fr) auto}"
         `shouldRenderFrom`
         gridTemplateColumns [upcast $ em 1, pct 20 @+@ fr 1, upcast $ auto]
 

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -26,7 +26,7 @@ spec = do
       columnGap (em 1)
 
   describe "gridTemplateRows" $ do
-    describe "keywords" $ do
+    describe "keyword" $ do
       "{grid-template-rows:none}"
         `shouldRenderFrom`
         gridTemplateRows none
@@ -37,7 +37,7 @@ spec = do
         gridTemplateRows [px 50, auto, em 40]
 
   describe "gridTemplateColumns" $ do
-    describe "keywords" $ do
+    describe "keyword" $ do
       "{grid-template-rows:none}"
         `shouldRenderFrom`
         gridTemplateRows none
@@ -47,10 +47,29 @@ spec = do
         `shouldRenderFrom`
         gridTemplateColumns [upcast $ em 1, pct 20 @+@ fr 1, upcast $ auto]
 
-    describe "gridArea" $ do
-      "{grid-area:header}"
-        `shouldRenderFrom`
-        gridArea "header"
+  describe "gridArea" $ do
+    "{grid-area:header}"
+      `shouldRenderFrom`
+      gridArea "header"
+
+  describe "grid coordinate properties" $ do
+
+    "{grid-row-start:3}"
+      `shouldRenderFrom`
+      gridRowStart 3
+
+    "{grid-row-end:-2}"
+      `shouldRenderFrom`
+      gridRowEnd (-2)
+
+    "{grid-column-start:span nav}"
+      `shouldRenderFrom`
+      gridColumnStart $ gridLocation Span (That "nav")
+
+    "{grid-column-end:3 footer}"
+      `shouldRenderFrom`
+      gridColumnEnd $ gridLocation NoSpan (These 3 "footer")
+
 
   describe "gridTemplateAreas" $ do
     describe "keyword values" $ do

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
+module Clay.GridSpec where
+
+import Test.Hspec
+import Common
+import Clay
+
+spec :: Spec
+spec = do
+  describe "grid-template-areas" $ do
+    describe "mozilla example" $ do
+      let
+        area_a = "a"
+        area_b = "b"
+        area_c = "c"
+        area_blank = "."
+
+      "{grid-template-areas:\"a a .\"\n\"a a .\"\n\". b c\"}"
+        `shouldRenderFrom`
+        gridTemplateAreas
+          [ [ area_a, area_a, area_blank]
+          , [ area_a, area_a, area_blank]
+          , [ area_blank, area_b, area_c]
+          ]
+    describe "non rectangular template areas should error" $ do
+      let
+        area_a = "a"
+        area_b = "b"
+        area_c = "c"
+        area_blank = "."
+
+      GridTemplateAreas_NotRectangular
+        `shouldErrorFromRender`
+        gridTemplateAreas
+          [ [ area_blank] -- length 1
+          , [ area_a, area_blank]         -- length 2
+          , [ area_blank, area_b, area_c] -- length 3
+          ]
+
+    describe "empty template should error" $ do
+      GridTemplateAreas_Empty
+        `shouldErrorFromRender`
+        gridTemplateAreas []
+
+    describe "template with empty row(s) should error" $ do
+      GridTemplateAreas_EmptyRow
+        `shouldErrorFromRender`
+        gridTemplateAreas [[], []]

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -5,6 +5,8 @@ module Clay.GridSpec where
 import Test.Hspec
 import Common
 import Clay
+import Data.These (These (..))
+
 
 spec :: Spec
 spec = do

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -9,12 +9,29 @@ import Clay
 spec :: Spec
 spec = do
   describe "grid-template-areas" $ do
+    describe "keyword values" $ do
+      "{grid-template-areas:none}"
+        `shouldRenderFrom`
+        gridTemplateAreas none
+
+      "{grid-template-areas:inherit}"
+        `shouldRenderFrom`
+        gridTemplateAreas inherit
+
+      "{grid-template-areas:initial}"
+        `shouldRenderFrom`
+        gridTemplateAreas initial
+
+      "{grid-template-areas:unset}"
+        `shouldRenderFrom`
+        gridTemplateAreas unset
+
     describe "mozilla example" $ do
       let
         area_a = "a"
         area_b = "b"
         area_c = "c"
-        area_blank = "."
+        area_blank = blankGridArea
 
       "{grid-template-areas:\"a a .\"\n\"a a .\"\n\". b c\"}"
         `shouldRenderFrom`
@@ -28,9 +45,9 @@ spec = do
         area_a = "a"
         area_b = "b"
         area_c = "c"
-        area_blank = "."
+        area_blank = blankGridArea
 
-      GridTemplateAreas_NotRectangular
+      GridTemplateNamedAreas_NotRectangular
         `shouldErrorFromRender`
         gridTemplateAreas
           [ [ area_blank]                 -- length 1
@@ -39,11 +56,11 @@ spec = do
           ]
 
     describe "empty template should error" $ do
-      GridTemplateAreas_Empty
+      GridTemplateNamedAreas_Empty
         `shouldErrorFromRender`
         gridTemplateAreas []
 
     describe "template with empty row(s) should error" $ do
-      GridTemplateAreas_EmptyRow
+      GridTemplateNamedAreas_EmptyRow
         `shouldErrorFromRender`
         gridTemplateAreas [[], []]

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -47,7 +47,12 @@ spec = do
         `shouldRenderFrom`
         gridTemplateColumns [SomeSize $ em 1, SomeSize $ pct 20, SomeSize minContent]
 
-  describe "grid-template-areas" $ do
+    describe "gridArea" $ do
+      "{grid-area:header}"
+        `shouldRenderFrom`
+        gridArea "header"
+
+  describe "gridTemplateAreas" $ do
     describe "keyword values" $ do
       "{grid-template-areas:none}"
         `shouldRenderFrom`

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -6,8 +6,6 @@ import Test.Hspec
 import Common
 import Clay
 
-test = hspec spec
-
 spec :: Spec
 spec = do
   describe "gap" $ do

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -6,8 +6,47 @@ import Test.Hspec
 import Common
 import Clay
 
+test = hspec spec
+
 spec :: Spec
 spec = do
+  describe "gap" $ do
+    "{gap:10px;grid-gap:10px}"
+      `shouldRenderFrom`
+      gap (px 10)
+
+  describe "rowGap" $ do
+    "{row-gap:5px;grid-row-gap:5px}"
+      `shouldRenderFrom`
+      rowGap (px 5)
+
+  describe "columnGap" $ do
+    "{column-gap:1em;grid-column-gap:1em}"
+      `shouldRenderFrom`
+      columnGap (em 1)
+
+  describe "gridTemplateRows" $ do
+    describe "keywords" $ do
+      "{grid-template-rows:none}"
+        `shouldRenderFrom`
+        gridTemplateRows none
+
+    describe "list of sizes" $ do
+      "{grid-template-rows:1em auto min-content}"
+        `shouldRenderFrom`
+        gridTemplateRows [SomeSize $ em 1, SomeSize auto, SomeSize minContent]
+
+  describe "gridTemplateColumns" $ do
+    describe "keywords" $ do
+      "{grid-template-rows:none}"
+        `shouldRenderFrom`
+        gridTemplateRows none
+
+    describe "list of sizes" $ do
+      "{grid-template-columns:1em 20% min-content}"
+        `shouldRenderFrom`
+        gridTemplateColumns [SomeSize $ em 1, SomeSize $ pct 20, SomeSize minContent]
+
   describe "grid-template-areas" $ do
     describe "keyword values" $ do
       "{grid-template-areas:none}"

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -32,9 +32,9 @@ spec = do
         gridTemplateRows none
 
     describe "list of sizes" $ do
-      "{grid-template-rows:50px auto 40em}"
+      "{grid-template-rows:50px auto minmax(400em,50%)}"
         `shouldRenderFrom`
-        gridTemplateRows [px 50, auto, em 40]
+        gridTemplateRows [upcast (px 50), upcast auto, minmax (em 400) (pct 50)]
 
   describe "gridTemplateColumns" $ do
     describe "keyword" $ do

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -26,8 +26,8 @@ spec = do
   describe "render results" $ do
     it "marginLeft auto" $
       (compactRender $ marginLeft auto) `shouldBe` "{margin-left:auto}"
-    it "marginLeft normal" $
-      (compactRender $ marginLeft normal) `shouldBe` "{margin-left:normal}"
+    it "marginLeft initial" $
+      (compactRender $ marginLeft initial) `shouldBe` "{margin-left:initial}"
     it "marginLeft inherit" $
       (compactRender $ marginLeft inherit) `shouldBe` "{margin-left:inherit}"
     it "marginLeft none" $

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -18,11 +18,6 @@ import Data.List
 sizeRepr :: Size a -> Text
 sizeRepr = plain . unValue . value
 
-hasAllPrefixes :: Val a => a -> Bool
-hasAllPrefixes a = checkPrefixed ((unValue . value) a) browsers
-  where checkPrefixed (Prefixed pa) (Prefixed pb) = sort (fmap fst pa) == sort (fmap fst pb)
-        checkPrefixed _ _ = False
-
 compactRender :: Css -> Text
 compactRender css = toStrict $ renderWith compact [] css
 
@@ -47,8 +42,6 @@ spec = do
       sizeRepr (em 2 @+@ px 1) `shouldBe` "calc(2em + 1px)"
     it "returns calc for nested sum" $
       sizeRepr (em 2 @+@ pt 1 @+@ px 3) `shouldBe` "calc((2em + 1pt) + 3px)"
-    it "returns prefixed calc for simple sum" $
-      (em 2 @+@ pt 2) `shouldSatisfy` hasAllPrefixes
     it "return calc for sum of different types" $
       sizeRepr (em 2 @+@ pct 10) `shouldBe` "calc(2em + 10%)"
     it "returns calc for simple difference" $

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -11,7 +11,6 @@ import Clay
 import Data.Text.Lazy (Text, unpack)
 import Control.Exception (evaluate)
 import Control.Exception (Exception(..), evaluate)
-import Control.DeepSeq (force)
 
 
 shouldRenderFrom :: Text -> Css -> SpecWith ()
@@ -34,6 +33,6 @@ testRender = renderWith compact []
 shouldErrorFromRender :: (Exception e, Eq e) => e -> Css -> SpecWith ()
 shouldErrorFromRender exception css = do
   let errorMsg = show exception
-  let rendered = evaluate $ force $ testRender css
+  let rendered = evaluate $! testRender css
   it ("throws " <> errorMsg) $
     (rendered `shouldThrow` (== exception))

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -9,7 +9,6 @@ module Common
 import Test.Hspec
 import Clay
 import Data.Text.Lazy (Text, unpack)
-import Control.Exception (evaluate)
 import Control.Exception (Exception(..), evaluate)
 
 

--- a/src/Clay/Common.hs
+++ b/src/Clay/Common.hs
@@ -28,6 +28,8 @@ class Initial    a where initial    :: a
 class Unset      a where unset      :: a
 class MinContent a where minContent :: a
 class MaxContent a where maxContent :: a
+class Row        a where row        :: a
+class Column     a where column     :: a
 
 -- | The other type class is used to escape from the type safety introduced by
 -- embedding CSS properties into the typed world of Clay. `Other` allows you to
@@ -61,6 +63,10 @@ minContentValue :: Value
 minContentValue = "min-content"
 maxContentValue :: Value
 maxContentValue = "max-content"
+rowValue :: Value
+rowValue = "row"
+columnValue :: Value
+columnValue = "column"
 
 instance All        Value where all        = allValue
 instance Auto       Value where auto       = autoValue
@@ -76,6 +82,8 @@ instance Initial    Value where initial    = initialValue
 instance Unset      Value where unset      = unsetValue
 instance MinContent Value where minContent = minContentValue
 instance MaxContent Value where maxContent = maxContentValue
+instance Row        Value where row        = rowValue
+instance Column     Value where column     = columnValue
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Common.hs
+++ b/src/Clay/Common.hs
@@ -15,17 +15,19 @@ import Data.String (IsString)
 
 -------------------------------------------------------------------------------
 
-class All      a where all      :: a
-class Auto     a where auto     :: a
-class Baseline a where baseline :: a
-class Center   a where center   :: a
-class Inherit  a where inherit  :: a
-class None     a where none     :: a
-class Normal   a where normal   :: a
-class Visible  a where visible  :: a
-class Hidden   a where hidden   :: a
-class Initial  a where initial  :: a
-class Unset    a where unset    :: a
+class All        a where all        :: a
+class Auto       a where auto       :: a
+class Baseline   a where baseline   :: a
+class Center     a where center     :: a
+class Inherit    a where inherit    :: a
+class None       a where none       :: a
+class Normal     a where normal     :: a
+class Visible    a where visible    :: a
+class Hidden     a where hidden     :: a
+class Initial    a where initial    :: a
+class Unset      a where unset      :: a
+class MinContent a where minContent :: a
+class MaxContent a where maxContent :: a
 
 -- | The other type class is used to escape from the type safety introduced by
 -- embedding CSS properties into the typed world of Clay. `Other` allows you to
@@ -55,19 +57,25 @@ initialValue :: Value
 initialValue = "initial"
 unsetValue :: Value
 unsetValue = "unset"
+minContentValue :: Value
+minContentValue = "min-content"
+maxContentValue :: Value
+maxContentValue = "max-content"
 
-instance All      Value where all      = allValue
-instance Auto     Value where auto     = autoValue
-instance Baseline Value where baseline = baselineValue
-instance Center   Value where center   = centerValue
-instance Inherit  Value where inherit  = inheritValue
-instance Normal   Value where normal   = normalValue
-instance None     Value where none     = noneValue
-instance Visible  Value where visible  = visibleValue
-instance Hidden   Value where hidden   = hiddenValue
-instance Other    Value where other    = id
-instance Initial  Value where initial  = initialValue
-instance Unset    Value where unset    = unsetValue
+instance All        Value where all        = allValue
+instance Auto       Value where auto       = autoValue
+instance Baseline   Value where baseline   = baselineValue
+instance Center     Value where center     = centerValue
+instance Inherit    Value where inherit    = inheritValue
+instance Normal     Value where normal     = normalValue
+instance None       Value where none       = noneValue
+instance Visible    Value where visible    = visibleValue
+instance Hidden     Value where hidden     = hiddenValue
+instance Other      Value where other      = id
+instance Initial    Value where initial    = initialValue
+instance Unset      Value where unset      = unsetValue
+instance MinContent Value where minContent = minContentValue
+instance MaxContent Value where maxContent = maxContentValue
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Flexbox.hs
+++ b/src/Clay/Flexbox.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleInstances, GeneralizedNewtypeDeriving, OverloadedStrings #-}
 module Clay.Flexbox where
 
-import Clay.Common     (Auto, Baseline, Center, Inherit, Other)
+import Clay.Common     (Auto, Baseline, Center, Inherit, Other, Row, Column)
 import Clay.Property
 import Clay.Size       (Size)
 import Clay.Stylesheet
@@ -66,13 +66,10 @@ flexBasis = key "flex-basis"
 -------------------------------------------------------------------------------
 
 newtype FlexDirection = FlexDirection Value
-  deriving (Val, Other)
+  deriving (Val, Other, Row, Column)
 
-row, rowReverse, column, columnReverse :: FlexDirection
-
-row           = FlexDirection "row"
+rowReverse, columnReverse :: FlexDirection
 rowReverse    = FlexDirection "row-reverse"
-column        = FlexDirection "column"
 columnReverse = FlexDirection "column-reverse"
 
 flexDirection :: FlexDirection -> Css

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -60,14 +60,23 @@ import Control.Monad (when)
 
 
 -- | Property sets the gaps (gutters) between rows and columns.
+-- Sets both "gap" & "grid-gap"
+-- to quote: https://developer.mozilla.org/en-US/docs/Web/CSS/gap
+-- "CSS Grid Layout initially defined the grid-gap property. This prefixed property is being replaced by gap. However, in order to support browsers that implemented grid-gap and not gap for grid, you will need to use the prefixed property"
 gap :: Size a -> Css
 gap = key "gap" <> key "grid-gap"
 
 -- | Property sets the size of the gap (gutter) between an element's grid rows.
+-- Sets both "row-gap" & "grid-row-gap"
+-- to quote: https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap
+-- "CSS Grid Layout initially defined the grid-row-gap property. This prefixed property is being replaced by row-gap. However, in order to support browsers that implemented grid-row-gap and not row-gap for grid, you will need to use the prefixed property."
 rowGap :: Size a -> Css
 rowGap = key "row-gap" <> key "grid-row-gap"
 
 -- | Property sets the size of the gap (gutter) between an element's grid columns.
+-- Sets both "column-gap" & "grid-column-gap"
+-- to quote: https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap
+-- "CSS Grid Layout initially defined the grid-column-gap property. This prefixed property is being replaced by column-gap. However, in order to support bcolumnsers that implemented grid-column-gap and not column-gap for grid, you will need to use the prefixed property."
 columnGap :: Size a -> Css
 columnGap = key "column-gap" <> key "grid-column-gap"
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -1,10 +1,12 @@
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE PatternSynonyms #-}
--- | Partial implementation of <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout>.
+{-# LANGUAGE
+    OverloadedStrings
+  , GeneralizedNewtypeDeriving
+  , TypeFamilies
+  , RankNTypes
+  , ExistentialQuantification
+  , PatternSynonyms
+  #-}
+-- | Implementation of <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout>.
 module Clay.Grid
   ( gap
   , rowGap

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -12,6 +12,9 @@ module Clay.Grid
   , gridTemplateRows
   , gridTemplateColumns
   , GridTrackList
+  , gridAutoRows
+  , gridAutoColumns
+  , GridAutoTrackList
   , gridArea
   , blankGridArea
   , GridArea
@@ -90,11 +93,11 @@ instance IsList (GridTrackList a) where
 
 -- | Property defines the line names and track sizing functions of the grid rows.
 gridAutoRows :: GridAutoTrackList a -> Css
-gridTemplateRows = key "grid-template-rows"
+gridAutoRows = key "grid-auto-rows"
 
 -- | Property defines the line names and track sizing functions of the grid columns.
 gridAutoColumns :: GridAutoTrackList a -> Css
-gridTemplateColumns = key "grid-template-columns"
+gridAutoColumns = key "grid-auto-columns"
 
 newtype GridAutoTrackList a = GridAutoTrackList Value
   deriving (Val, Auto, MinContent, MaxContent, Inherit, Initial, Unset)

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -87,6 +87,25 @@ instance IsList (GridTrackList a) where
   fromList = GridTrackList . noCommas
 
 -------------------------------------------------------------------------------
+
+-- | Property defines the line names and track sizing functions of the grid rows.
+gridAutoRows :: GridAutoTrackList a -> Css
+gridTemplateRows = key "grid-template-rows"
+
+-- | Property defines the line names and track sizing functions of the grid columns.
+gridAutoColumns :: GridAutoTrackList a -> Css
+gridTemplateColumns = key "grid-template-columns"
+
+newtype GridAutoTrackList a = GridAutoTrackList Value
+  deriving (Val, Auto, MinContent, MaxContent, Inherit, Initial, Unset)
+
+instance IsList (GridAutoTrackList a) where
+  type Item (GridAutoTrackList a) = Size a
+  toList = error ""
+  fromList = GridAutoTrackList . noCommas
+
+
+-------------------------------------------------------------------------------
 -- | Property defines the element location inside grid template
 gridArea :: GridArea -> Css
 gridArea = key "grid-area"

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -247,5 +247,3 @@ data InvalidGridTemplate
   | InvalidGridTemplateEmptyRow
   | InvalidGridTemplateNotRectangular
   deriving (Eq, Show)
-
-instance Exception InvalidGridTemplate

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -109,5 +109,7 @@ instance Val GridTemplateAreas where
   value areas =
     value $
     Text.intercalate "\n" $
-    fmap (Text.intercalate " ") $
+    fmap (quote . Text.intercalate " ") $
     (coerce areas :: [[Text]])
+    where
+      quote text = "\"" <> text <> "\""

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -157,37 +157,39 @@ gridColumnEnd :: GridLocation -> Css
 gridColumnEnd = key "grid-column-end"
 
 gridLocation :: IsSpan -> These Integer GridArea -> GridLocation
-gridLocation isSpan = GridLocation_Data . GridLocationData isSpan
+gridLocation isSpan = GridLocationData . MkGridLocationData isSpan
 
 data IsSpan = Span | NoSpan
   deriving (Show, Eq)
 
 data GridLocation
-  = GridLocation_Keyword Value
-  | GridLocation_Data GridLocationData
+  = GridLocationKeyword Value
+  | GridLocationData GridLocationData
 
 instance Val GridLocation where
-  value (GridLocation_Keyword v) = v
-  value (GridLocation_Data d) = value d
+  value (GridLocationKeyword v) = v
+  value (GridLocationData d)    = value d
 
-instance Auto    GridLocation where auto    = GridLocation_Keyword auto
-instance Inherit GridLocation where inherit = GridLocation_Keyword inherit
-instance Initial GridLocation where initial = GridLocation_Keyword initial
-instance Unset   GridLocation where unset   = GridLocation_Keyword unset
+instance Auto    GridLocation where auto    = GridLocationKeyword auto
+instance Inherit GridLocation where inherit = GridLocationKeyword inherit
+instance Initial GridLocation where initial = GridLocationKeyword initial
+instance Unset   GridLocation where unset   = GridLocationKeyword unset
 
 -- See under syntax:
 -- https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-start
 -- either grid index and/or named grid area is required, but span is optional
-data GridLocationData = GridLocationData IsSpan (These Integer GridArea)
+-- Note: constuctor is not exported, 'GridIndex, or 'gridLocationData to fill this info in
+data GridLocationData = MkGridLocationData IsSpan (These Integer GridArea)
+
 
 instance Val GridLocationData where
-  value (GridLocationData isSpan indexAndOrGridArea) =
+  value (MkGridLocationData isSpan indexAndOrGridArea) =
     if isSpan == Span
     then value (span :: Value, indexAndOrGridArea)
     else value indexAndOrGridArea
 
 pattern GridIndex :: Integer -> GridLocation
-pattern GridIndex n = GridLocation_Data (GridLocationData NoSpan (This n))
+pattern GridIndex n = GridLocationData (MkGridLocationData NoSpan (This n))
 
 instance Num GridLocation where
   -- for index literals

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -38,7 +38,7 @@ module Clay.Grid
   , unGridTemplateNamedAreas
   , InvalidGridTemplateNamedAreas(..)
   -- re exports
-  , These(..)
+  , module Data.These
   -- deprecated
   , gridGap
 
@@ -49,11 +49,12 @@ import Clay.Common
 import Clay.Property
 import Clay.Size
 import Clay.Stylesheet
+import Clay.Elements (span)
 
+import Prelude hiding (span)
 import Data.String (IsString)
 import Data.Text (Text)
 import qualified Data.Text as Text
-
 import Data.Coerce (coerce)
 import Data.These
 import GHC.Exts (IsList(..))
@@ -172,13 +173,16 @@ instance Inherit GridLocation where inherit = GridLocation_Keyword inherit
 instance Initial GridLocation where initial = GridLocation_Keyword initial
 instance Unset   GridLocation where unset   = GridLocation_Keyword unset
 
+-- See under syntax:
+-- https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-start
+-- either grid index and/or named grid area is required, but span is optional
 data GridLocationData = GridLocationData IsSpan (These Integer GridArea)
 
 instance Val GridLocationData where
-  value (GridLocationData isSpan coordinateAndOrGridArea) =
+  value (GridLocationData isSpan indexAndOrGridArea) =
     if isSpan == Span
-    then value ("span" :: Text, coordinateAndOrGridArea)
-    else value coordinateAndOrGridArea
+    then value (span :: Value, indexAndOrGridArea)
+    else value indexAndOrGridArea
 
 pattern GridIndex :: Integer -> GridLocation
 pattern GridIndex n = GridLocation_Data (GridLocationData NoSpan (This n))

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -236,7 +236,7 @@ instance Val GridTemplateNamedAreas where
 -- | toList will throw when your grid template areas are invalid
 instance IsList GridTemplateNamedAreas where
   type Item GridTemplateNamedAreas = [GridArea]
-  toList = unGridTemplateNamedAreas . coerce
+  toList = unGridTemplateNamedAreas
   fromList = either throw id . mkGridTemplateNamedAreas
     where
       fromRightOrThrow :: Exception e => Either e a -> a

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -238,10 +238,6 @@ instance IsList GridTemplateNamedAreas where
   type Item GridTemplateNamedAreas = [GridArea]
   toList = unGridTemplateNamedAreas
   fromList = either throw id . mkGridTemplateNamedAreas
-    where
-      fromRightOrThrow :: Exception e => Either e a -> a
-      fromRightOrThrow (Right a) = a
-      fromRightOrThrow (Left e) = throw e
 
 -- | Smart constructor for GridTemplateNamedAreas
 mkGridTemplateNamedAreas :: [[GridArea]] -> Either InvalidGridTemplateNamedAreas GridTemplateNamedAreas

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -110,7 +110,7 @@ gridAutoColumns :: GridAutoTrackList a -> Css
 gridAutoColumns = key "grid-auto-columns"
 
 newtype GridAutoTrackList a = GridAutoTrackList Value
-  deriving (Val, Auto, MinContent, MaxContent, Inherit, Initial, Unset)
+  deriving (Val, Auto, MinContent, MaxContent)
 
 mkGridAutoTrackList :: [Size a] -> GridAutoTrackList
 mkGridAutoTrackList = GridAutoTrackList . noCommas

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -15,6 +15,12 @@ module Clay.Grid
   , gridAutoRows
   , gridAutoColumns
   , GridAutoTrackList
+  , gridAutoFlow
+  , row
+  , column
+  , dense
+  , rowDense
+  , columnDense
   , gridArea
   , blankGridArea
   , GridArea
@@ -107,7 +113,21 @@ instance IsList (GridAutoTrackList a) where
   toList = error ""
   fromList = GridAutoTrackList . noCommas
 
+-------------------------------------------------------------------------------
+gridAutoFlow :: GridAutoFlow -> Css
+gridAutoFlow = key "grid-auto-flow"
 
+newtype GridAutoFlow = GridAutoFlow Value
+  deriving (Val, Row, Column, Inherit, Initial, Unset)
+
+dense :: GridAutoFlow
+dense = GridAutoFlow "dense"
+
+rowDense :: GridAutoFlow
+rowDense = GridAutoFlow "row dense"
+
+columnDense :: GridAutoFlow
+columnDense = GridAutoFlow "column dense"
 -------------------------------------------------------------------------------
 -- | Property defines the element location inside grid template
 gridArea :: GridArea -> Css

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -39,9 +39,6 @@ module Clay.Grid
   , InvalidGridTemplateNamedAreas(..)
   -- re exports
   , These(..)
-  -- deprecated
-  , gridGap
-
   )
   where
 
@@ -65,10 +62,6 @@ import Control.Monad (when)
 -- | Property sets the gaps (gutters) between rows and columns.
 gap :: Size a -> Css
 gap = key "gap" <> key "grid-gap"
-
-gridGap :: Size a -> Css
-gridGap = gap
-{-# DEPRECATED gridGap "Use gap, rowGap, and/or columnGap instead" #-}
 
 -- | Property sets the size of the gap (gutter) between an element's grid rows.
 rowGap :: Size a -> Css
@@ -267,4 +260,3 @@ data InvalidGridTemplateNamedAreas
   deriving (Eq, Show)
 
 instance Exception InvalidGridTemplateNamedAreas
-------------------------------------------------------------------------------

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -36,7 +36,7 @@ module Clay.Grid
   , gridTemplateAreas
   , GridTemplateAreas
   , GridTemplateNamedAreas
-  , InvalidGridTemplateNamedAreas(..)
+  , InvalidGridTemplate(..)
   -- re exports
   , These(..)
   )
@@ -242,28 +242,29 @@ instance IsList GridTemplateNamedAreas where
   fromList = either throw id . mkGridTemplateNamedAreas
 
 -- | Smart constructor for GridTemplateNamedAreas
-mkGridTemplateNamedAreas :: [[GridArea]] -> Either InvalidGridTemplateNamedAreas GridTemplateNamedAreas
+mkGridTemplateNamedAreas :: [[GridArea]] -> Either InvalidGridTemplate GridTemplateNamedAreas
 mkGridTemplateNamedAreas rows = do
     let
       counts = fmap length (coerce rows :: [[GridArea]])
-      longest = maximum counts
+      shortestRowLength = minimum counts
 
     when (null rows) $
-      Left GridTemplateNamedAreas_Empty
+      Left InvalidGridTemplateEmpty
 
-    when (any (== 0) counts)  $
-      Left GridTemplateNamedAreas_EmptyRow
+    when (shortestRowLength == 0) $
+      Left InvalidGridTemplateEmptyRow
 
-    when (any (/= longest) counts)  $
-      Left GridTemplateNamedAreas_NotRectangular
+    when (any (/= shortestRowLength) counts)  $
+      Left InvalidGridTemplateNotRectangular
 
     Right $ GridTemplateNamedAreas rows
 
--- | Failure modes for the smart constructor
-data InvalidGridTemplateNamedAreas
-  = GridTemplateNamedAreas_Empty
-  | GridTemplateNamedAreas_EmptyRow
-  | GridTemplateNamedAreas_NotRectangular
+
+-- | Possible failure modes for 'mkGridTemplateNamedAreas
+data InvalidGridTemplate
+  = InvalidGridTemplateEmpty
+  | InvalidGridTemplateEmptyRow
+  | InvalidGridTemplateNotRectangular
   deriving (Eq, Show)
 
-instance Exception InvalidGridTemplateNamedAreas
+instance Exception InvalidGridTemplate

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -237,7 +237,7 @@ instance Val GridTemplateNamedAreas where
 instance IsList GridTemplateNamedAreas where
   type Item GridTemplateNamedAreas = [GridArea]
   toList = unGridTemplateNamedAreas . coerce
-  fromList = fromRightOrThrow . mkGridTemplateNamedAreas
+  fromList = either throw id . mkGridTemplateNamedAreas
     where
       fromRightOrThrow :: Exception e => Either e a -> a
       fromRightOrThrow (Right a) = a

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -154,7 +154,7 @@ gridColumnEnd :: GridLocation -> Css
 gridColumnEnd = key "grid-column-end"
 
 gridLocation :: IsSpan -> These Integer GridArea -> GridLocation
-gridLocation isSpan these = GridLocation_Data $ GridLocationData isSpan these
+gridLocation isSpan = GridLocation_Data . GridLocationData isSpan
 
 data IsSpan = Span | NoSpan
   deriving (Show, Eq)
@@ -172,15 +172,7 @@ instance Inherit GridLocation where inherit = GridLocation_Keyword inherit
 instance Initial GridLocation where initial = GridLocation_Keyword initial
 instance Unset   GridLocation where unset   = GridLocation_Keyword unset
 
-data GridLocationData = GridLocationData
-  { gridLocation_span                    :: IsSpan
-  , gridLocation_coordinateAndOrGridArea :: These Integer GridArea
-  }
-
-instance (Val a, Val b) => Val (These a b) where
-  value (This a) = value a
-  value (That b) = value b
-  value (These a b) = value (a, b)
+data GridLocationData = GridLocationData IsSpan (These Integer GridArea)
 
 instance Val GridLocationData where
   value (GridLocationData isSpan coordinateAndOrGridArea) =
@@ -192,8 +184,16 @@ pattern GridIndex :: Integer -> GridLocation
 pattern GridIndex n = GridLocation_Data (GridLocationData NoSpan (This n))
 
 instance Num GridLocation where
+  -- for index literals
   fromInteger = GridIndex
+  -- for negative index literals
   negate (GridIndex index) = GridIndex $ negate index
+  -- in general we don't support arithmetic on this type
+  negate _ = error "negate not defined for GridLocation"
+  abs = error "abs not defined for GridLocation"
+  signum = error "abs not defined for GridLocation"
+  (+) = error "addition not defined for GridLocation"
+  (*) = error "multiplication not defined for GridLocation"
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -36,11 +36,9 @@ module Clay.Grid
   , gridTemplateAreas
   , GridTemplateAreas
   , GridTemplateNamedAreas
-  , mkGridTemplateNamedAreas
-  , unGridTemplateNamedAreas
   , InvalidGridTemplateNamedAreas(..)
   -- re exports
-  , module Data.These
+  , These(..)
   -- deprecated
   , gridGap
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -43,6 +43,7 @@
 -- @
 module Clay.Grid
   ( gap
+  , gridGap
   , rowGap
   , columnGap
   , gridTemplateRows
@@ -67,8 +68,12 @@ import GHC.Exts (IsList(..))
 
 
 -- | Property sets the gaps (gutters) between rows and columns.
-gap :: Size a -> Css
-gap = key "gap" <> key "grid-gap"
+gap :: Size a -> Size a -> Css
+gap row col = key "gap" (row, col) <> key "grid-gap" (row, col)
+
+gridGap :: Size a -> Css
+gridGap = key "grid-gap"
+{-# DEPRECATED gridGap "Use gap, rowGap, and/or columnGap instead" #-}
 
 -- | Property sets the size of the gap (gutter) between an element's grid rows.
 rowGap :: Size a -> Css

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -11,7 +11,6 @@ module Clay.Grid
   , gridTemplateRows
   , gridTemplateColumns
   , GridTemplateSizes
-  , SomeSize(..)
   , gridTemplateAreas
   , gridArea
   , blankGridArea
@@ -58,11 +57,11 @@ columnGap :: Size a -> Css
 columnGap = key "column-gap" <> key "grid-column-gap"
 
 -- | Property defines the line names and track sizing functions of the grid rows.
-gridTemplateRows :: GridTemplateSizes -> Css
+gridTemplateRows :: GridTemplateSizes a -> Css
 gridTemplateRows = key "grid-template-rows"
 
 -- | Property defines the line names and track sizing functions of the grid columns.
-gridTemplateColumns :: GridTemplateSizes -> Css
+gridTemplateColumns :: GridTemplateSizes a -> Css
 gridTemplateColumns = key "grid-template-columns"
 
 -- | Property defines the template for grid layout
@@ -80,16 +79,11 @@ blankGridArea :: GridArea
 blankGridArea = GridArea "."
 
 -------------------------------------------------------------------------------
-data SomeSize = forall a. SomeSize { getSize :: Size a }
-
-instance Val SomeSize where
-  value (SomeSize size) = value size
-
-newtype GridTemplateSizes = GridTemplateSizes Value
+newtype GridTemplateSizes a = GridTemplateSizes Value
   deriving (Val, None, Inherit, Initial, Unset)
 
-instance IsList GridTemplateSizes where
-  type Item GridTemplateSizes = SomeSize
+instance IsList (GridTemplateSizes a) where
+  type Item (GridTemplateSizes a) = Size a
   toList = error ""
   fromList = GridTemplateSizes . noCommas
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -250,7 +250,7 @@ mkGridTemplateNamedAreas rows = do
       counts = fmap length (coerce rows :: [[GridArea]])
       longest = maximum counts
 
-    when (null rows ) $
+    when (null rows) $
       Left GridTemplateNamedAreas_Empty
 
     when (any (== 0) counts)  $

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -11,7 +11,7 @@ module Clay.Grid
   , columnGap
   , gridTemplateRows
   , gridTemplateColumns
-  , GridTemplateSizes
+  , GridTrackList
   , gridArea
   , blankGridArea
   , GridArea
@@ -71,20 +71,20 @@ columnGap = key "column-gap" <> key "grid-column-gap"
 -------------------------------------------------------------------------------
 
 -- | Property defines the line names and track sizing functions of the grid rows.
-gridTemplateRows :: GridTemplateSizes a -> Css
+gridTemplateRows :: GridTrackList a -> Css
 gridTemplateRows = key "grid-template-rows"
 
 -- | Property defines the line names and track sizing functions of the grid columns.
-gridTemplateColumns :: GridTemplateSizes a -> Css
+gridTemplateColumns :: GridTrackList a -> Css
 gridTemplateColumns = key "grid-template-columns"
 
-newtype GridTemplateSizes a = GridTemplateSizes Value
+newtype GridTrackList a = GridTrackList Value
   deriving (Val, None, Inherit, Initial, Unset)
 
-instance IsList (GridTemplateSizes a) where
-  type Item (GridTemplateSizes a) = Size a
+instance IsList (GridTrackList a) where
+  type Item (GridTrackList a) = Size a
   toList = error ""
-  fromList = GridTemplateSizes . noCommas
+  fromList = GridTrackList . noCommas
 
 -------------------------------------------------------------------------------
 -- | Property defines the element location inside grid template

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -149,6 +149,8 @@ instance Val GridLocationData where
 
 instance Num GridLocation where
   fromInteger = gridLocation NoSpan . This
+  negate (GridLocation_Data (GridLocationData NoSpan (This index))) =
+    fromInteger $ negate index
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -56,6 +56,8 @@ rowGap = key "row-gap" <> key "grid-row-gap"
 columnGap :: Size a -> Css
 columnGap = key "column-gap" <> key "grid-column-gap"
 
+-------------------------------------------------------------------------------
+
 -- | Property defines the line names and track sizing functions of the grid rows.
 gridTemplateRows :: GridTemplateSizes a -> Css
 gridTemplateRows = key "grid-template-rows"
@@ -64,21 +66,6 @@ gridTemplateRows = key "grid-template-rows"
 gridTemplateColumns :: GridTemplateSizes a -> Css
 gridTemplateColumns = key "grid-template-columns"
 
--- | Property defines the template for grid layout
-gridTemplateAreas :: GridTemplateAreas -> Css
-gridTemplateAreas = key "grid-template-areas"
-
--- | Property defines the element location inside grid template
-gridArea :: GridArea -> Css
-gridArea = key "grid-area"
-
-newtype GridArea = GridArea Text
-  deriving (IsString, Val)
-
-blankGridArea :: GridArea
-blankGridArea = GridArea "."
-
--------------------------------------------------------------------------------
 newtype GridTemplateSizes a = GridTemplateSizes Value
   deriving (Val, None, Inherit, Initial, Unset)
 
@@ -88,6 +75,41 @@ instance IsList (GridTemplateSizes a) where
   fromList = GridTemplateSizes . noCommas
 
 -------------------------------------------------------------------------------
+-- | Property defines the element location inside grid template
+gridArea :: GridArea -> Css
+gridArea = key "grid-area"
+
+blankGridArea :: GridArea
+blankGridArea = GridArea "."
+
+newtype GridArea = GridArea Text
+  deriving (IsString, Val)
+
+-------------------------------------------------------------------------------
+
+gridRowStart :: GridCoordinate -> Css
+gridRowStart = key "grid-row-start"
+
+gridRowEnd :: GridCoordinate -> Css
+gridRowEnd = key "grid-row-end"
+
+gridColumnStart :: GridCoordinate -> Css
+gridColumnStart = key "grid-column-start"
+
+gridColumnEnd :: GridCoordinate -> Css
+gridColumnEnd = key "grid-column-end"
+
+newtype GridCoordinate = GridCoordinate Value
+  deriving (Val, Auto, Inherit, Initial, Unset)
+
+instance Num GridCoordinate where
+  fromInteger = GridCoordinate . value
+-------------------------------------------------------------------------------
+
+-- | Property defines the template for grid layout
+gridTemplateAreas :: GridTemplateAreas -> Css
+gridTemplateAreas = key "grid-template-areas"
+
 newtype GridTemplateAreas = GridTemplateAreas Value
   deriving (Val, None, Inherit, Initial, Unset)
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -14,9 +14,11 @@ module Clay.Grid
   , gridTemplateRows
   , gridTemplateColumns
   , GridTrackList
+  , mkGridTrackList
   , gridAutoRows
   , gridAutoColumns
   , GridAutoTrackList
+  , mkGridAutoTrackList
   , gridAutoFlow
   , row
   , column
@@ -110,10 +112,8 @@ gridAutoColumns = key "grid-auto-columns"
 newtype GridAutoTrackList a = GridAutoTrackList Value
   deriving (Val, Auto, MinContent, MaxContent, Inherit, Initial, Unset)
 
-instance IsList (GridAutoTrackList a) where
-  type Item (GridAutoTrackList a) = Size a
-  toList = error ""
-  fromList = GridAutoTrackList . noCommas
+mkGridAutoTrackList :: [Size a] -> GridAutoTrackList
+mkGridAutoTrackList = GridAutoTrackList . noCommas
 
 -------------------------------------------------------------------------------
 gridAutoFlow :: GridAutoFlow -> Css
@@ -190,18 +190,6 @@ instance Val GridLocationData where
 pattern GridIndex :: Integer -> GridLocation
 pattern GridIndex n = GridLocationData (MkGridLocationData NoSpan (This n))
 
-instance Num GridLocation where
-  -- for index literals
-  fromInteger = GridIndex
-  -- for negative index literals
-  negate (GridIndex index) = GridIndex $ negate index
-  -- in general we don't support arithmetic on this type
-  negate _ = error "negate not defined for GridLocation"
-  abs = error "abs not defined for GridLocation"
-  signum = error "abs not defined for GridLocation"
-  (+) = error "addition not defined for GridLocation"
-  (*) = error "multiplication not defined for GridLocation"
-
 -------------------------------------------------------------------------------
 
 -- | Property defines the template for grid layout
@@ -233,12 +221,6 @@ instance Val GridTemplateNamedAreas where
       Text.intercalate "\n" $
       fmap convertRow $
       rows
-
--- | toList will throw when your grid template areas are invalid
-instance IsList GridTemplateNamedAreas where
-  type Item GridTemplateNamedAreas = [GridArea]
-  toList = unGridTemplateNamedAreas
-  fromList = either throw id . mkGridTemplateNamedAreas
 
 -- | Smart constructor for GridTemplateNamedAreas
 mkGridTemplateNamedAreas :: [[GridArea]] -> Either InvalidGridTemplate GridTemplateNamedAreas

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -93,10 +93,9 @@ gridTemplateColumns = key "grid-template-columns"
 newtype GridTrackList a = GridTrackList Value
   deriving (Val, None, Inherit, Initial, Unset)
 
-instance IsList (GridTrackList a) where
-  type Item (GridTrackList a) = Size a
-  toList = error ""
-  fromList = GridTrackList . noCommas
+-- | Create a GridTrackList from a list of sizes
+mkGridTrackList :: [Size a] -> GridTrackList a
+mkGridTrackList = GridTrackList . noCommas
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -177,7 +177,7 @@ instance Unset   GridLocation where unset   = GridLocationKeyword unset
 -- See under syntax:
 -- https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column-start
 -- either grid index and/or named grid area is required, but span is optional
--- Note: constuctor is not exported, 'GridIndex, or 'gridLocationData to fill this info in
+-- Note: constructor is not exported, 'GridIndex, or 'gridLocationData to fill this info in
 data GridLocationData = MkGridLocationData IsSpan (These Integer GridArea)
 
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE PatternSynonyms #-}
 -- | Partial implementation of <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout>.
 module Clay.Grid
   ( gap
@@ -39,9 +40,7 @@ import Clay.Common
 import Clay.Property
 import Clay.Size
 import Clay.Stylesheet
-import Clay.Elements
 
-import Prelude hiding (span)
 import Data.String (IsString)
 import Data.Text (Text)
 import qualified Data.Text as Text
@@ -147,10 +146,12 @@ instance Val GridLocationData where
     then value ("span" :: Text, coordinateAndOrGridArea)
     else value coordinateAndOrGridArea
 
+pattern GridIndex :: Integer -> GridLocation
+pattern GridIndex n = GridLocation_Data (GridLocationData NoSpan (This n))
+
 instance Num GridLocation where
-  fromInteger = gridLocation NoSpan . This
-  negate (GridLocation_Data (GridLocationData NoSpan (This index))) =
-    fromInteger $ negate index
+  fromInteger = GridIndex
+  negate (GridIndex index) = GridIndex $ negate index
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Property.hs
+++ b/src/Clay/Property.hs
@@ -8,6 +8,7 @@ import Data.List.NonEmpty (NonEmpty, toList)
 import Data.Maybe
 import Data.String
 import Data.Text (Text, replace)
+import Data.These (These(..))
 
 data Prefixed = Prefixed { unPrefixed :: [(Text, Text)] } | Plain { unPlain :: Text }
   deriving (Show, Eq)
@@ -99,6 +100,11 @@ instance Val a => Val [a] where
 
 instance Val a => Val (NonEmpty a) where
   value = value . toList
+
+instance (Val a, Val b) => Val (These a b) where
+  value (This a) = value a
+  value (That b) = value b
+  value (These a b) = value (a, b)
 
 intercalate :: Monoid a => a -> [a] -> a
 intercalate _ []     = mempty

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -185,14 +185,6 @@ vmax i = SimpleSize (cssDoubleText i <> "vmax")
 -- | 'SimpleSize' in fr's (a fractional unit and 1fr is for 1 part of the available space in grid areas).
 fr i = SimpleSize (cssDoubleText i <> "fr")
 
--- | SimpleSize for the intrinsic preferred width.
-maxContent :: Size LengthUnit
-maxContent = SimpleSize "max-content"
-
--- | SimpleSize for the intrinsic minimum width.
-minContent :: Size LengthUnit
-minContent = SimpleSize "min-content"
-
 -- | SimpleSize for the containing block width minus horizontal margin, border, and padding.
 available :: Size LengthUnit
 available = SimpleSize "available"

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -119,7 +119,7 @@ sizeToText (OtherSize a) = plain $ unValue a
 instance Val (Size a) where
   value (SimpleSize a) = value a
   value (OtherSize a) = a
-  value s = Value $ browsers <> Plain ("calc" <> sizeToText s)
+  value s = Value $ Plain ("calc" <> sizeToText s)
 
 instance Auto (Size a) where auto = OtherSize Clay.Common.autoValue
 instance Normal (Size a) where normal = OtherSize Clay.Common.normalValue

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -127,10 +127,15 @@ instance Val (Size a) where
   value s@(FitContentSize _) = Value $ Plain $ sizeToText s
   value s = Value $ Plain ("calc" <> sizeToText s)
 
-instance Auto (Size a) where auto = OtherSize Clay.Common.autoValue
-instance Normal (Size a) where normal = OtherSize Clay.Common.normalValue
-instance Inherit (Size a) where inherit = OtherSize Clay.Common.inheritValue
-instance None (Size a) where none = OtherSize Clay.Common.noneValue
+-- Keywords
+instance Auto       (Size a) where auto       = OtherSize auto
+instance Inherit    (Size a) where inherit    = OtherSize inherit
+instance Initial    (Size a) where initial    = OtherSize initial
+instance Unset      (Size a) where unset      = OtherSize inherit
+instance None       (Size a) where none       = OtherSize none
+instance MinContent (Size a) where minContent = OtherSize minContent
+instance MaxContent (Size a) where maxContent = OtherSize maxContent
+
 instance Other (Size a) where other a = OtherSize a
 
 -- | Zero size.
@@ -186,13 +191,6 @@ vmax i = SimpleSize (cssDoubleText i <> "vmax")
 
 -- | 'SimpleSize' in fr's (a fractional unit and 1fr is for 1 part of the available space in grid areas).
 fr i = SimpleSize (cssDoubleText i <> "fr")
-
--- | Keyword min-content size
-instance MinContent (Size LengthUnit) where minContent = OtherSize minContent
-
--- | Keyword max-content size
-instance MaxContent (Size LengthUnit) where maxContent = OtherSize maxContent
--- | SimpleSize for the containing block width minus horizontal margin, border, and padding.
 
 -- | The larger of the intrinsic minimum width or the smaller of the intrinsic preferred width and the available width.
 fitContent :: Size a -> Size a

--- a/src/Clay/Size.hs
+++ b/src/Clay/Size.hs
@@ -14,6 +14,8 @@ module Clay.Size
   Size
 , LengthUnit
 , Percentage
+, AnyUnit
+, upcast
 , nil
 , unitless
 
@@ -74,6 +76,7 @@ where
 import Data.Monoid
 import Prelude hiding (rem)
 import Data.Text (Text)
+import Data.Coerce (coerce)
 
 import Clay.Common
 import Clay.Property
@@ -88,7 +91,12 @@ data LengthUnit
 data Percentage
 
 -- | When combining percentages with units using calc, we get a combination
-data Combination
+-- | Any unit or combination of units
+data AnyUnit
+
+-- | Upcast a size unit
+upcast :: Size a -> Size AnyUnit
+upcast = coerce
 
 data Size a =
   SimpleSize Text |
@@ -222,7 +230,7 @@ instance Fractional (Size Percentage) where
 type family SizeCombination sa sb where
   SizeCombination Percentage Percentage = Percentage
   SizeCombination LengthUnit LengthUnit = LengthUnit
-  SizeCombination a b = Combination
+  SizeCombination a b = AnyUnit
 
 -- | Plus operator to combine sizes into calc function
 infixl 6 @+@


### PR DESCRIPTION
Resolves #176 

Explicit support for all grid properties listed on mdn, except for a handful of shorthand properties:
 - [grid](https://developer.mozilla.org/en-US/docs/Web/CSS/grid)
 - [grid-row]( https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row)
 - [grid-column]( https://developer.mozilla.org/en-US/docs/Web/CSS/grid-column)
 - [grid-template](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template)

The above shorthands have involved syntax which would make them a pain to support. The finer grained methods still encapsulate all the grid layout options.

I'm mostly happy with how this pr turned out. The main shortcoming for me is `upcast`. I tried a number of other things, but none of them worked very well.  What would be nice here is Impredicative Polymorphism. I want to be able to create a list of type `[forall a. Size a]` for `gridTemplateRows`/`gridTemplateColumns`, but GHC won't oblige me. Maybe something to revisit when we get [Quick Look](https://gitlab.haskell.org/ghc/ghc/-/issues/18126)?