### PR TITLE
Cubic bezier argument list should be comma separated

### DIFF
--- a/clay.cabal
+++ b/clay.cabal
@@ -81,6 +81,7 @@ Library
 Test-Suite Test-Clay
   Type: exitcode-stdio-1.0
   HS-Source-Dirs: spec, src
+  Build-Tools: hspec-discover
   main-is: Spec.hs
   Build-Depends:
     base                 >= 4.11  && < 5,

--- a/spec/Clay/TransitionSpec.hs
+++ b/spec/Clay/TransitionSpec.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Clay.TransitionSpec where
+
+import Test.Hspec
+import Clay
+import Common
+
+spec :: Spec
+spec = do
+  describe "transition" $ do
+    describe "generates proper code" $ do
+      it "renders cubic-bezier" $ 
+        (plain (unValue (value (cubicBezier 1.0 2.0 3.0 4.0))))
+        `shouldBe`
+        "cubic-bezier(1,2,3,4)"

--- a/src/Clay/Transition.hs
+++ b/src/Clay/Transition.hs
@@ -93,7 +93,7 @@ stepsStart s = other ("steps(" <> value s <> ", start)")
 stepsStop  s = other ("steps(" <> value s <> ", end)")
 
 cubicBezier :: Double -> Double -> Double -> Double -> TimingFunction
-cubicBezier a b c d = other ("cubic-bezier(" <> value (a ! b ! c ! d) <> ")")
+cubicBezier a b c d = other ("cubic-bezier(" <> value [a, b, c, d] <> ")")
 
 transitionTimingFunction :: TimingFunction -> Css
 transitionTimingFunction = key "transition-timing-function"


### PR DESCRIPTION
(According to Chrome and w3schools.)