### PR TITLE
Adds Not type class, Fixes #239

### DIFF
--- a/spec/Clay/PseudoSpec.hs
+++ b/spec/Clay/PseudoSpec.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE OverloadedStrings, OverloadedLists, TypeApplications #-}
+module Clay.PseudoSpec where
+
+import Test.Hspec
+import Clay
+import Common
+import Prelude hiding (not, div)
+
+spec :: Spec
+spec = do
+  describe "not pseudo selector" $ do
+    describe "applied to a selector" $ do
+      ":not(p){display:none}" `shouldRenderFrom` not p & display none
+    describe "applied to a refinement" $ do
+      "input:not(:checked){display:none}" `shouldRenderFrom` input # not checked ? display none
+    describe "applied to both a selector and a refinement" $ do
+      ":not(#some-input:not(:checked)){display:none}" `shouldRenderFrom` not ("#some-input" # not checked) & display none
+    describe "applied to a overloaded string" $ do
+      "#some-input:not(:checked) ~ #some-div > div:not(.test){display:none}" `shouldRenderFrom` "#some-input" # not checked |~ "#some-div" |> div # not @Clay.Selector ".test" ? display none

--- a/src/Clay/Pseudo.hs
+++ b/src/Clay/Pseudo.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Clay.Pseudo where
 
 import Data.Text (Text)
 
-import Clay.Render (renderSelector)
+import Clay.Render (renderSelector, renderRefinement)
 import Clay.Selector
 
 import qualified Data.Text.Lazy as Lazy
@@ -64,5 +66,19 @@ nthLastChild  n = func "nth-last-child"   [n]
 nthLastOfType n = func "nth-last-of-type" [n]
 nthOfType     n = func "nth-of-type"      [n]
 
-not :: Selector -> Refinement
-not r = func "not" [Lazy.toStrict (renderSelector r)]
+-- | The 'not' pseudo selector can be applied to both a 'Refinement'
+--
+-- > input # not checked
+-- 
+-- or a 'Selector'
+--
+-- > not p
+
+class Not a where
+  not :: a -> Refinement
+
+instance Not Selector where
+  not r = func "not" [Lazy.toStrict (renderSelector r)]
+
+instance Not Refinement where
+  not r = func "not" (Lazy.toStrict <$> renderRefinement r)

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -122,7 +122,6 @@ renderSelector :: Selector -> Lazy.Text
 renderSelector = toLazyText . selector compact
 
 -- | Render a CSS `Refinement`.
-
 renderRefinement :: Refinement -> [Lazy.Text]
 renderRefinement r = toLazyText . predicate <$> unFilter r
 

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -8,6 +8,7 @@ module Clay.Render
 , putCss
 , renderWith
 , renderSelector
+, renderRefinement
 , withBanner
 )
 where
@@ -119,6 +120,11 @@ renderWith cfg top
 
 renderSelector :: Selector -> Lazy.Text
 renderSelector = toLazyText . selector compact
+
+-- | Render a CSS `Refinement`.
+
+renderRefinement :: Refinement -> [Lazy.Text]
+renderRefinement r = toLazyText . predicate <$> unFilter r
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The `not` pseudo selector can only be applied to one argument at a time in most browsers, Safari seems to be the exception. The instance for `Not Refinement` allows you to apply `Not` to multiple arguments, however, there is no contaminator to combine two `Refinement` directly.