### PR TITLE
A couple of changes related to media queries

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 CHANGELOG
 
+  Unreleased:
+    - Add `all` media type.
+    - Support `prefers-color-scheme` media feature.
+
   0.14.0:
     - Drop support for GHC 8.2
     - Added `text-align-last`

--- a/src/Clay/Media.hs
+++ b/src/Clay/Media.hs
@@ -37,6 +37,16 @@ module Clay.Media
 , Resolution
 , dpi
 , dppx
+
+-- * Preference related features.
+
+, prefersColorScheme
+
+-- ** Preference related values.
+
+, ColorScheme
+, light
+, dark
 )
 
 where
@@ -140,3 +150,20 @@ dpi i = Resolution (value (pack (show i) <> "dpi"))
 dppx :: Integer -> Resolution
 dppx i = Resolution (value (pack (show i) <> "dppx"))
 
+-------------------------------------------------------------------------------
+
+-- | Feature detecting whether user prefers light or dark color scheme.
+prefersColorScheme :: ColorScheme -> Feature
+prefersColorScheme = with "prefers-color-scheme"
+
+-- | A color scheme preferred by a user.
+newtype ColorScheme = ColorScheme Value
+  deriving (Val, Other)
+
+-- | User indicates that they prefer a light theme with their interface.
+light :: ColorScheme
+light = ColorScheme (value (pack "light"))
+
+-- | User indicates that they prefer a dark theme with their interface.
+dark :: ColorScheme
+dark = ColorScheme (value (pack "dark"))

--- a/src/Clay/Media.hs
+++ b/src/Clay/Media.hs
@@ -4,8 +4,11 @@ module Clay.Media
 
 -- * Media types.
 
-  aural, braille, handheld, print, projection
-, screen, tty, tv, embossed
+  all, screen, print
+
+-- | The media types which follow were defined in CSS2.1 and Media Queries 3,
+-- but they were deprecated in Media Queries 4 and should not be used.
+, aural, braille, handheld, projection, tty, tv, embossed
 
 -- * Geometrical features.
 
@@ -40,7 +43,7 @@ where
 import Data.Text (Text, pack)
 import Data.Monoid
 
-import Clay.Common
+import Clay.Common hiding (all)
 import Clay.Size
 import Clay.Property
 import Clay.Stylesheet
@@ -49,14 +52,18 @@ import Prelude hiding (all, print)
 
 -------------------------------------------------------------------------------
 
-aural, braille, handheld, print, projection
+all, aural, braille, handheld, print, projection
   , screen, tty, tv, embossed :: MediaType
 
+-- | Suitable for all devices.
+all        = MediaType "all"
 aural      = MediaType "aural"
 braille    = MediaType "braille"
 handheld   = MediaType "handheld"
+-- | Intended primarily for printed material or in a print layout.
 print      = MediaType "print"
 projection = MediaType "projection"
+-- | Intended primarily for screen-based devices.
 screen     = MediaType "screen"
 tty        = MediaType "tty"
 tv         = MediaType "tv"

--- a/src/Clay/Media.hs
+++ b/src/Clay/Media.hs
@@ -160,7 +160,8 @@ prefersColorScheme = with "prefers-color-scheme"
 newtype ColorScheme = ColorScheme Value
   deriving (Val, Other)
 
--- | User indicates that they prefer a light theme with their interface.
+-- | User indicates that they prefer a light theme with their interface,
+-- or that they have not indicated a preference.
 light :: ColorScheme
 light = ColorScheme (value (pack "light"))
 

--- a/src/Clay/Media.hs
+++ b/src/Clay/Media.hs
@@ -6,8 +6,9 @@ module Clay.Media
 
   all, screen, print
 
--- | The media types which follow were defined in CSS2.1 and Media Queries 3,
--- but they were deprecated in Media Queries 4 and should not be used.
+-- ** Deprecated.
+
+-- | These media types were deprecated by Media Queries 4.
 , aural, braille, handheld, projection, tty, tv, embossed
 
 -- * Geometrical features.


### PR DESCRIPTION
These are a couple of changes related to media queries:

* Adds the `all` media type.  A [reference](https://developer.mozilla.org/en-US/docs/Web/CSS/@media#media_types) mentions that media types other than `all`, `screen`, and `print` were deprecated, so documentation was updated to mention this fact.

* Adds support for the [`prefers-color-scheme`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) media feature.

I have also added a few documentation comments while making these changes.  If they were intentionally omitted for other functions, then I'd be happy to remove them.
