### PR TITLE
Add tests for the Clay.Media module

### DIFF
--- a/spec/Clay/MediaSpec.hs
+++ b/spec/Clay/MediaSpec.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clay.MediaSpec (spec) where
+
+import Clay (Css, em, query)
+import Clay.Media
+import Clay.Stylesheet (Feature, MediaType)
+import Common
+import Data.Text.Lazy (Text, unpack)
+import Test.Hspec
+import Prelude hiding (all, print)
+
+spec :: Spec
+spec = do
+  describe "media types" $ do
+    "all" `shouldRenderFromMediaType` all
+    "screen" `shouldRenderFromMediaType` screen
+    "print" `shouldRenderFromMediaType` print
+
+    context "with deprecated types" $ do
+      "aural" `shouldRenderFromMediaType` aural
+      "braille" `shouldRenderFromMediaType` braille
+      "handheld" `shouldRenderFromMediaType` handheld
+      "projection" `shouldRenderFromMediaType` projection
+      "tty" `shouldRenderFromMediaType` tty
+      "tv" `shouldRenderFromMediaType` tv
+      "embossed" `shouldRenderFromMediaType` embossed
+
+  describe "geometrical features" $ do
+    "width: 11em" `shouldRenderFromFeature` width (em 11)
+    "min-width: 12em" `shouldRenderFromFeature` minWidth (em 12)
+    "max-width: 13em" `shouldRenderFromFeature` maxWidth (em 13)
+    "height: 14em" `shouldRenderFromFeature` height (em 14)
+    "min-height: 15em" `shouldRenderFromFeature` minHeight (em 15)
+    "max-height: 16em" `shouldRenderFromFeature` maxHeight (em 16)
+    "device-width: 17em" `shouldRenderFromFeature` deviceWidth (em 17)
+    "min-device-width: 18em" `shouldRenderFromFeature` minDeviceWidth (em 18)
+    "max-device-width: 19em" `shouldRenderFromFeature` maxDeviceWidth (em 19)
+    "device-height: 20em" `shouldRenderFromFeature` deviceHeight (em 20)
+    "min-device-height: 21em" `shouldRenderFromFeature` minDeviceHeight (em 21)
+    "max-device-height: 22em" `shouldRenderFromFeature` maxDeviceHeight (em 22)
+
+  describe "aspect ratio features" $ do
+    "aspect-ratio: 2/3" `shouldRenderFromFeature` aspectRatio (2, 3)
+    "min-aspect-ratio: 4/5" `shouldRenderFromFeature` minAspectRatio (4, 5)
+    "max-aspect-ratio: 6/7" `shouldRenderFromFeature` maxAspectRatio (6, 7)
+    "device-aspect-ratio: 2/3" `shouldRenderFromFeature` deviceAspectRatio (2, 3)
+    "min-device-aspect-ratio: 4/5" `shouldRenderFromFeature` minDeviceAspectRatio (4, 5)
+    "max-device-aspect-ratio: 6/7" `shouldRenderFromFeature` maxDeviceAspectRatio (6, 7)
+
+  describe "color features" $ do
+    xdescribe "features must be surrounded by parantheses" $ do
+      "color" `shouldRenderFromFeature` color
+      "monochrome" `shouldRenderFromFeature` monochrome
+      "scan" `shouldRenderFromFeature` scan
+      "grid" `shouldRenderFromFeature` grid
+    "min-color: 23" `shouldRenderFromFeature` minColor 23
+    "max-color: 25" `shouldRenderFromFeature` maxColor 25
+    "color-index: 15" `shouldRenderFromFeature` colorIndex 15
+    "min-color-index: 17" `shouldRenderFromFeature` minColorIndex 17
+    "max-color-index: 19" `shouldRenderFromFeature` maxColorIndex 19
+    "min-monochrome: 77" `shouldRenderFromFeature` minMonochrome 77
+    "max-monochrome: 99" `shouldRenderFromFeature` maxMonochrome 99
+
+  describe "resolution features" $ do
+    "resolution: 45dpi" `shouldRenderFromFeature` resolution (dpi 45)
+    "resolution: 74dppx" `shouldRenderFromFeature` resolution (dppx 74)
+    "min-resolution: 45dpi" `shouldRenderFromFeature` minResolution (dpi 45)
+    "min-resolution: 74dppx" `shouldRenderFromFeature` minResolution (dppx 74)
+    "max-resolution: 45dpi" `shouldRenderFromFeature` maxResolution (dpi 45)
+    "max-resolution: 74dppx" `shouldRenderFromFeature` maxResolution (dppx 74)
+
+  describe "preference features" $ do
+    "prefers-color-scheme: light" `shouldRenderFromFeature` prefersColorScheme light
+    "prefers-color-scheme: dark" `shouldRenderFromFeature` prefersColorScheme dark
+
+-- | Empty CSS for when CSS is needed but we don't care about it.
+emptyStyle :: Css
+emptyStyle = pure ()
+
+-- | The text should be rendered from the media type.
+shouldRenderFromMediaType :: Text -> MediaType -> SpecWith ()
+shouldRenderFromMediaType text mediaType =
+  shouldRenderAsFrom (unpack text) fullText css
+  where
+    fullText = "@media " <> text <> "{}"
+    css = query mediaType [] emptyStyle
+
+-- | The text should be rendered from the feature.
+shouldRenderFromFeature :: Text -> Feature -> SpecWith ()
+shouldRenderFromFeature text feature =
+  shouldRenderAsFrom (unpack text) fullText css
+  where
+    fullText = "@media all and (" <> text <> "){}"
+    css = query all [feature] emptyStyle
+
+infixr 0 `shouldRenderFromMediaType`
+
+infixr 0 `shouldRenderFromFeature`

--- a/spec/Clay/MediaSpec.hs
+++ b/spec/Clay/MediaSpec.hs
@@ -49,11 +49,10 @@ spec = do
     "max-device-aspect-ratio: 6/7" `shouldRenderFromFeature` maxDeviceAspectRatio (6, 7)
 
   describe "color features" $ do
-    xdescribe "features must be surrounded by parantheses" $ do
-      "color" `shouldRenderFromFeature` color
-      "monochrome" `shouldRenderFromFeature` monochrome
-      "scan" `shouldRenderFromFeature` scan
-      "grid" `shouldRenderFromFeature` grid
+    "color" `shouldRenderFromFeature` color
+    "monochrome" `shouldRenderFromFeature` monochrome
+    "scan" `shouldRenderFromFeature` scan
+    "grid" `shouldRenderFromFeature` grid
     "min-color: 23" `shouldRenderFromFeature` minColor 23
     "max-color: 25" `shouldRenderFromFeature` maxColor 25
     "color-index: 15" `shouldRenderFromFeature` colorIndex 15

--- a/src/Clay/Render.hs
+++ b/src/Clay/Render.hs
@@ -184,7 +184,7 @@ mediaType (MediaType (Value v)) = fromText (plain v)
 feature :: Feature -> Builder
 feature (Feature k mv) =
   case mv of
-    Nothing        -> fromText k
+    Nothing        -> mconcat [ "(", fromText k, ")" ]
     Just (Value v) -> mconcat
       [ "(" , fromText k , ": " , fromText (plain v) , ")" ]
 


### PR DESCRIPTION
I was bothered by the lack of tests, so I added some for this single module.  Adding more tests covering the entire library would be nice, but that was too ambitious to do in one go.

In the process, I noticed that there was a bug when rendering a key-only media feature such as `color`.  The syntax for Media Queries requires that media features always be surrounded by parentheses, but Clay omitted parentheses for these features.  So I also made a change to the `Clay.Render` module.

https://w3c.github.io/csswg-drafts/mediaqueries-5/#mq-syntax