### PR TITLE
Support for gride size and position

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 CHANGELOG
 
   Unreleased:
+    - Add grid size and location support.
     - Add `all` media type.
     - Support `prefers-color-scheme` media feature.
 

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+
+module Clay.GridSpec where
+
+import Test.Hspec
+import Common
+import Clay
+
+spec :: Spec
+spec = do
+  describe "grid row start" $ do
+    "{grid-row-start:3}"
+      `shouldRenderFrom`
+      gridRowStart 3
+
+    "{grid-row-start:-2}"
+      `shouldRenderFrom`
+      gridRowStart (-2)
+
+    "{grid-row-start:span nav}"
+      `shouldRenderFrom`
+      gridRowStart $ span_ "nav"
+
+    "{grid-row-start:footer 4}"
+      `shouldRenderFrom`
+      gridRowStart ("footer", 4)
+
+  describe "grid row" $ do
+
+    "{grid-row:nav}"
+      `shouldRenderFrom`
+      gridRow "nav"
+
+    "{grid-row:3 / span 2}"
+      `shouldRenderFrom`
+      gridRow $ 3 // span_ 2
+
+    "{grid-row:nav / 2}"
+      `shouldRenderFrom`
+      gridRow $ "nav" // 2
+
+    -- Must not compile as grid-row only accepts up to 2 arguments.
+    -- gridRow $ "nav" // 2 // 3
+
+  describe "grid area" $ do
+    "{grid-area:3}"
+      `shouldRenderFrom`
+      gridArea $ 3
+
+    "{grid-area:2 / nav}"
+      `shouldRenderFrom`
+      gridArea $ 2 // "nav"
+
+    "{grid-area:nav 2 / span 3 / 4}"
+      `shouldRenderFrom`
+      gridArea $ ("nav", 2) // span_ 3 // 4
+
+    "{grid-area:nav / span nav 3 / 4 / nav 3}"
+      `shouldRenderFrom`
+      gridArea $ "nav" // span_ ("nav", 3) // 4 // ("nav", 3)
+
+    -- Must not compile as grid-area only accepts up to 4 arguments.
+    -- gridArea $ 1 // 2 // 3 // 4 // 5

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -41,9 +41,9 @@ spec = do
       `shouldRenderFrom`
       gridRowStart $ span_ 3
 
-    "{grid-row-start:span somegridarea}"
+    "{grid-row-start:span -somegridarea}"
       `shouldRenderFrom`
-      gridRowStart $ span_ "somegridarea"
+      gridRowStart $ span_ "-somegridarea"
 
     "{grid-row-start:span somegridarea 5}"
       `shouldRenderFrom`
@@ -72,6 +72,16 @@ spec = do
       gridRowStart ("somegridarea", 0)
         `shouldThrowErrorCall`
         "Value 0 is invalid"
+
+    it "throw error when custom-ident start with number" $ do
+      gridRowStart "0test"
+        `shouldThrowErrorCall`
+        "Custom-ident cannot start with a number"
+
+    it "throw error when custom-ident start with number in span_" $ do
+      gridRowStart (span_ "2test")
+        `shouldThrowErrorCall`
+        "Custom-ident cannot start with a number"
 
   describe "grid row end" $ do
 

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -47,7 +47,7 @@ spec = do
   describe "grid area" $ do
     "{grid-area:3}"
       `shouldRenderFrom`
-      gridArea $ 3
+      gridArea 3
 
     "{grid-area:2 / nav}"
       `shouldRenderFrom`

--- a/spec/Clay/GridSpec.hs
+++ b/spec/Clay/GridSpec.hs
@@ -11,55 +11,433 @@ import Clay
 spec :: Spec
 spec = do
   describe "grid row start" $ do
-    "{grid-row-start:3}"
+
+    "{grid-row-start:auto}"
       `shouldRenderFrom`
-      gridRowStart 3
+      gridRowStart (auto :: GridLine)
+
+    "{grid-row-start:somegridarea}"
+      `shouldRenderFrom`
+      gridRowStart "somegridarea"
+
+    "{grid-row-start:2}"
+      `shouldRenderFrom`
+      gridRowStart 2
 
     "{grid-row-start:-2}"
       `shouldRenderFrom`
       gridRowStart (-2)
 
-    "{grid-row-start:span nav}"
+    "{grid-row-start:somegridarea 4}"
       `shouldRenderFrom`
-      gridRowStart $ span_ "nav"
+      gridRowStart ("somegridarea", 4)
 
-    "{grid-row-start:footer 4}"
+    "{grid-row-start:span 3}"
       `shouldRenderFrom`
-      gridRowStart ("footer", 4)
+      gridRowStart $ span_ 3
+
+    "{grid-row-start:span somegridarea}"
+      `shouldRenderFrom`
+      gridRowStart $ span_ "somegridarea"
+
+    "{grid-row-start:span somegridarea 5}"
+      `shouldRenderFrom`
+      gridRowStart $ span_ ("somegridarea", 5)
+
+    "{grid-row-start:inherit}"
+      `shouldRenderFrom`
+      gridRowStart (inherit :: GridLine)
+
+    "{grid-row-start:initial}"
+      `shouldRenderFrom`
+      gridRowStart (initial :: GridLine)
+
+    "{grid-row-start:unset}"
+      `shouldRenderFrom`
+      gridRowStart (unset :: GridLine)
+
+  describe "grid row start errors" $ do
+
+    it "throw error when value is 0" $ do
+      gridRowStart 0
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+    it "throw error when second value is 0" $ do
+      gridRowStart ("somegridarea", 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+  describe "grid row end" $ do
+
+    "{grid-row-end:auto}"
+      `shouldRenderFrom`
+      gridRowEnd (auto :: GridLine)
+
+    "{grid-row-end:somegridarea}"
+      `shouldRenderFrom`
+      gridRowEnd "somegridarea"
+
+    "{grid-row-end:2}"
+      `shouldRenderFrom`
+      gridRowEnd 2
+
+    "{grid-row-end:-2}"
+      `shouldRenderFrom`
+      gridRowEnd (-2)
+
+    "{grid-row-end:somegridarea 4}"
+      `shouldRenderFrom`
+      gridRowEnd ("somegridarea", 4)
+
+    "{grid-row-end:span 3}"
+      `shouldRenderFrom`
+      gridRowEnd $ span_ 3
+
+    "{grid-row-end:span somegridarea}"
+      `shouldRenderFrom`
+      gridRowEnd $ span_ "somegridarea"
+
+    "{grid-row-end:span somegridarea 5}"
+      `shouldRenderFrom`
+      gridRowEnd $ span_ ("somegridarea", 5)
+
+    "{grid-row-end:inherit}"
+      `shouldRenderFrom`
+      gridRowEnd (inherit :: GridLine)
+
+    "{grid-row-end:initial}"
+      `shouldRenderFrom`
+      gridRowEnd (initial :: GridLine)
+
+    "{grid-row-end:unset}"
+      `shouldRenderFrom`
+      gridRowEnd (unset :: GridLine)
+
+  describe "grid row end errors" $ do
+
+    it "throw error when value is 0" $ do
+      gridRowEnd 0
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+    it "throw error when second value is 0" $ do
+      gridRowEnd ("somegridarea", 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
 
   describe "grid row" $ do
 
-    "{grid-row:nav}"
+    "{grid-row:auto}"
       `shouldRenderFrom`
-      gridRow "nav"
+      gridRow (auto :: GridLine)
 
-    "{grid-row:3 / span 2}"
+    "{grid-row:auto / auto}"
       `shouldRenderFrom`
-      gridRow $ 3 // span_ 2
+      gridRow $ (auto :: GridLine) // (auto :: GridLine)
 
-    "{grid-row:nav / 2}"
+    "{grid-row:somegridarea}"
       `shouldRenderFrom`
-      gridRow $ "nav" // 2
+      gridRow "somegridarea"
+
+    "{grid-row:somegridarea / someothergridarea}"
+      `shouldRenderFrom`
+      gridRow $ "somegridarea" // "someothergridarea"
+
+    "{grid-row:somegridarea 4}"
+      `shouldRenderFrom`
+      gridRow ("somegridarea", 4)
+
+    "{grid-row:somegridarea 4 / 6}"
+      `shouldRenderFrom`
+      gridRow $ ("somegridarea", 4) // 6
+
+    "{grid-row:span 3}"
+      `shouldRenderFrom`
+      gridRow $ span_ 3
+
+    "{grid-row:span somegridarea}"
+      `shouldRenderFrom`
+      gridRow $ span_ "somegridarea"
+
+    "{grid-row:span somegridarea 5}"
+      `shouldRenderFrom`
+      gridRow $ span_ ("somegridarea", 5)
+
+    "{grid-row:span 3 / 6}"
+      `shouldRenderFrom`
+      gridRow $ span_ 3 // 6
+
+    "{grid-row:span somegridarea / span someothergridarea}"
+      `shouldRenderFrom`
+      gridRow $ span_ "somegridarea" // span_ "someothergridarea"
+
+    "{grid-row:span somegridarea 5 / span 2}"
+      `shouldRenderFrom`
+      gridRow $ span_ ("somegridarea", 5) // span_ 2
+
+    "{grid-row:inherit}"
+      `shouldRenderFrom`
+      gridRow (inherit :: GridLine)
+
+    "{grid-row:initial}"
+      `shouldRenderFrom`
+      gridRow (initial :: GridLine)
+
+    "{grid-row:unset}"
+      `shouldRenderFrom`
+      gridRow (unset :: GridLine)
+
+  describe "grid row errors" $ do
+
+    it "throw error when value is 0" $ do
+      gridRow 0
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+    it "throw error when second value is 0" $ do
+      gridRow ("somegridarea", 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+    it "throw error when span value is 0" $ do
+      gridRow (span_ 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+    it "throw error when span value is negative" $ do
+      gridRow (span_ (-1))
+        `shouldThrowErrorCall`
+        "Value -1 is invalid"
+
+    it "throw error when second span value is negative" $ do
+      gridRow (span_ ("somegridarea", (-1)))
+        `shouldThrowErrorCall`
+        "Value -1 is invalid"
+
+    it "throw error when second grid value is 0" $ do
+      gridRow (1 // 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
 
     -- Must not compile as grid-row only accepts up to 2 arguments.
     -- gridRow $ "nav" // 2 // 3
 
+  describe "grid column start" $ do
+
+    "{grid-column-start:auto}"
+      `shouldRenderFrom`
+      gridColumnStart (auto :: GridLine)
+
+    "{grid-column-start:somegridarea}"
+      `shouldRenderFrom`
+      gridColumnStart "somegridarea"
+
+    "{grid-column-start:2}"
+      `shouldRenderFrom`
+      gridColumnStart 2
+
+    "{grid-column-start:somegridarea 4}"
+      `shouldRenderFrom`
+      gridColumnStart ("somegridarea", 4)
+
+    "{grid-column-start:span 3}"
+      `shouldRenderFrom`
+      gridColumnStart $ span_ 3
+
+    "{grid-column-start:span somegridarea}"
+      `shouldRenderFrom`
+      gridColumnStart $ span_ "somegridarea"
+
+    "{grid-column-start:span somegridarea 5}"
+      `shouldRenderFrom`
+      gridColumnStart $ span_ ("somegridarea", 5)
+
+    "{grid-column-start:inherit}"
+      `shouldRenderFrom`
+      gridColumnStart (inherit :: GridLine)
+
+    "{grid-column-start:initial}"
+      `shouldRenderFrom`
+      gridColumnStart (initial :: GridLine)
+
+    "{grid-column-start:unset}"
+      `shouldRenderFrom`
+      gridColumnStart (unset :: GridLine)
+
+  describe "grid column end" $ do
+
+    "{grid-column-end:auto}"
+      `shouldRenderFrom`
+      gridColumnEnd (auto :: GridLine)
+
+    "{grid-column-end:somegridarea}"
+      `shouldRenderFrom`
+      gridColumnEnd "somegridarea"
+
+    "{grid-column-end:2}"
+      `shouldRenderFrom`
+      gridColumnEnd 2
+
+    "{grid-column-end:somegridarea 4}"
+      `shouldRenderFrom`
+      gridColumnEnd ("somegridarea", 4)
+
+    "{grid-column-end:span 3}"
+      `shouldRenderFrom`
+      gridColumnEnd $ span_ 3
+
+    "{grid-column-end:span somegridarea}"
+      `shouldRenderFrom`
+      gridColumnEnd $ span_ "somegridarea"
+
+    "{grid-column-end:span somegridarea 5}"
+      `shouldRenderFrom`
+      gridColumnEnd $ span_ ("somegridarea", 5)
+
+    "{grid-column-end:inherit}"
+      `shouldRenderFrom`
+      gridColumnEnd (inherit :: GridLine)
+
+    "{grid-column-end:initial}"
+      `shouldRenderFrom`
+      gridColumnEnd (initial :: GridLine)
+
+    "{grid-column-end:unset}"
+      `shouldRenderFrom`
+      gridColumnEnd (unset :: GridLine)
+
+  describe "grid column" $ do
+
+    "{grid-column:auto}"
+      `shouldRenderFrom`
+      gridColumn (auto :: GridLine)
+
+    "{grid-column:auto / auto}"
+      `shouldRenderFrom`
+      gridColumn $ (auto :: GridLine) // (auto :: GridLine)
+
+    "{grid-column:somegridarea}"
+      `shouldRenderFrom`
+      gridColumn "somegridarea"
+
+    "{grid-column:somegridarea / someothergridarea}"
+      `shouldRenderFrom`
+      gridColumn $ "somegridarea" // "someothergridarea"
+
+    "{grid-column:somegridarea 4}"
+      `shouldRenderFrom`
+      gridColumn ("somegridarea", 4)
+
+    "{grid-column:somegridarea 4 / 6}"
+      `shouldRenderFrom`
+      gridColumn $ ("somegridarea", 4) // 6
+
+    "{grid-column:span 3}"
+      `shouldRenderFrom`
+      gridColumn $ span_ 3
+
+    "{grid-column:span somegridarea}"
+      `shouldRenderFrom`
+      gridColumn $ span_ "somegridarea"
+
+    "{grid-column:span somegridarea 5}"
+      `shouldRenderFrom`
+      gridColumn $ span_ ("somegridarea", 5)
+
+    "{grid-column:span 3 / 6}"
+      `shouldRenderFrom`
+      gridColumn $ span_ 3 // 6
+
+    "{grid-column:span somegridarea / span someothergridarea}"
+      `shouldRenderFrom`
+      gridColumn $ span_ "somegridarea" // span_ "someothergridarea"
+
+    "{grid-column:span somegridarea 5 / span 2}"
+      `shouldRenderFrom`
+      gridColumn $ span_ ("somegridarea", 5) // span_ 2
+
+    "{grid-column:inherit}"
+      `shouldRenderFrom`
+      gridColumn (inherit :: GridLine)
+
+    "{grid-column:initial}"
+      `shouldRenderFrom`
+      gridColumn (initial :: GridLine)
+
+    "{grid-column:unset}"
+      `shouldRenderFrom`
+      gridColumn (unset :: GridLine)
+
   describe "grid area" $ do
-    "{grid-area:3}"
-      `shouldRenderFrom`
-      gridArea 3
 
-    "{grid-area:2 / nav}"
+    "{grid-area:auto}"
       `shouldRenderFrom`
-      gridArea $ 2 // "nav"
+      gridArea (auto :: GridLine)
 
-    "{grid-area:nav 2 / span 3 / 4}"
+    "{grid-area:auto / auto}"
       `shouldRenderFrom`
-      gridArea $ ("nav", 2) // span_ 3 // 4
+      gridArea $ (auto :: GridLine) // (auto :: GridLine)
 
-    "{grid-area:nav / span nav 3 / 4 / nav 3}"
+    "{grid-area:auto / auto / auto}"
       `shouldRenderFrom`
-      gridArea $ "nav" // span_ ("nav", 3) // 4 // ("nav", 3)
+      gridArea $ (auto :: GridLine) // (auto :: GridLine) // (auto :: GridLine)
+
+    "{grid-area:auto / auto / auto / auto}"
+      `shouldRenderFrom`
+      gridArea $
+           (auto :: GridLine)
+        // (auto :: GridLine)
+        // (auto :: GridLine)
+        // (auto :: GridLine)
+
+    "{grid-area:somegridarea}"
+      `shouldRenderFrom`
+      gridArea "somegridarea"
+
+    "{grid-area:somegridarea / someothergridarea}"
+      `shouldRenderFrom`
+      gridArea $ "somegridarea" // "someothergridarea"
+
+    "{grid-area:somegridarea 4}"
+      `shouldRenderFrom`
+      gridArea ("somegridarea", 4)
+
+    "{grid-area:somegridarea 4 / someothergridarea 2}"
+      `shouldRenderFrom`
+      gridArea $ ("somegridarea", 4) // ("someothergridarea", 2)
+
+    "{grid-area:span 3}"
+      `shouldRenderFrom`
+      gridArea $ span_ 3
+
+    "{grid-area:span 3 / span somegridarea}"
+      `shouldRenderFrom`
+      gridArea $ span_ 3 // span_ "somegridarea"
+
+    "{grid-area:inherit}"
+      `shouldRenderFrom`
+      gridArea (inherit :: GridLine)
+
+    "{grid-area:initial}"
+      `shouldRenderFrom`
+      gridArea (initial :: GridLine)
+
+    "{grid-area:unset}"
+      `shouldRenderFrom`
+      gridArea (unset :: GridLine)
+
+  describe "grid area errors" $ do
+
+    it "throw error when third value is 0" $ do
+      gridArea (1 // 1 // 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
+
+    it "throw error when fourth value is 0" $ do
+      gridArea (1 // 1 // 1 // 0)
+        `shouldThrowErrorCall`
+        "Value 0 is invalid"
 
     -- Must not compile as grid-area only accepts up to 4 arguments.
     -- gridArea $ 1 // 2 // 3 // 4 // 5

--- a/spec/Clay/SizeSpec.hs
+++ b/spec/Clay/SizeSpec.hs
@@ -13,7 +13,7 @@ import Clay.Stylesheet
 import Test.Hspec
 import Data.Text
 import Data.Text.Lazy (toStrict)
-import Data.List
+import Data.List (sort)
 
 sizeRepr :: Size a -> Text
 sizeRepr = plain . unValue . value

--- a/spec/Common.hs
+++ b/spec/Common.hs
@@ -2,6 +2,7 @@ module Common where
 
 import Test.Hspec
 import Clay
+import Control.Exception (evaluate)
 import Data.Text.Lazy (Text, unpack)
 
 shouldRenderFrom :: Text -> Css -> SpecWith ()
@@ -17,3 +18,10 @@ infixr 3 `shouldRenderAsFrom`
 shouldRenderItFrom :: Text -> Css -> Expectation
 shouldRenderItFrom = flip $ shouldBe . renderWith compact []
 infixr 0 `shouldRenderItFrom`
+
+-- | Test succesfull if, after being evaluated, the error call message
+-- raised by the 'Css' argument is equal to the provided 'String'.
+shouldThrowErrorCall :: Css -> String -> Expectation
+shouldThrowErrorCall css txt =
+  evaluate (renderWith compact [] css) `shouldThrow` errorCall txt
+infixr 0 `shouldThrowErrorCall`

--- a/src/Clay/Color.hs
+++ b/src/Clay/Color.hs
@@ -178,10 +178,10 @@ lerp factor startColor boundColor =
 instance Val Color where
   value clr =
     case clr of
-      Rgba r g b 1.0 -> Value $mconcat ["#",  p' r, p' g, p' b]
-      Rgba r g b a   -> Value $mconcat ["rgba(", p r, ",", p g, ",", p b, ",", ah a, ")"]
-      Hsla h s l 1.0 -> Value $mconcat ["hsl(",  p h, ",", f s, ",", f l,            ")"]
-      Hsla h s l a   -> Value $mconcat ["hsla(", p h, ",", f s, ",", f l, ",", ah a, ")"]
+      Rgba r g b 1.0 -> Value $ mconcat ["#",  p' r, p' g, p' b]
+      Rgba r g b a   -> Value $ mconcat ["rgba(", p r, ",", p g, ",", p b, ",", ah a, ")"]
+      Hsla h s l 1.0 -> Value $ mconcat ["hsl(",  p h, ",", f s, ",", f l,            ")"]
+      Hsla h s l a   -> Value $ mconcat ["hsla(", p h, ",", f s, ",", f l, ",", ah a, ")"]
       Other o        -> o
     where p  = fromString . show
           p' = fromString . printf "%02x"

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -1,4 +1,10 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# OPTIONS_GHC -Wno-type-defaults #-}
+
 -- | Partial implementation of <https://alligator.io/css/css-grid-layout-grid-areas grid area CSS API>.
 --
 -- For instance, you want to generate the following CSS:
@@ -40,14 +46,30 @@
 --    width maxContent
 -- @
 module Clay.Grid
-( gridGap
-, gridTemplateColumns
+(   -- * Style properties.
+    gridGap
+  , gridTemplateColumns
+  , gridArea
+  , gridColumn
+  , gridColumnStart
+  , gridColumnEnd
+  , gridRow
+  , gridRowStart
+  , gridRowEnd
+
+    -- * Keywords
+  , (//)
+  , span_
 )
 where
 
-import Clay.Property
-import Clay.Size
-import Clay.Stylesheet
+import qualified Clay.Common as Com
+import           Clay.Property (Val, noCommas, value)
+import           Clay.Size (Size)
+import           Clay.Stylesheet (Css, key)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import           Prelude hiding (span)
 
 -- | Property sets the gaps (gutters) between rows and columns.
 gridGap :: Size a -> Css
@@ -56,3 +78,244 @@ gridGap = key "grid-gap"
 -- | Property defines the line names and track sizing functions of the grid columns.
 gridTemplateColumns :: [Size a] -> Css
 gridTemplateColumns = key "grid-template-columns" . noCommas
+
+-- | Property shorthand specifies a grid item's size and location
+-- within a grid.
+gridArea :: ToGridLines4 a => a -> Css
+gridArea x = key "grid-area" (toGridLines x)
+
+-- | Property shorthand specifies a grid item's size and location
+-- within a grid column.
+gridColumn :: ToGridLines2 a => a -> Css
+gridColumn x = key "grid-column" (toGridLines2 x)
+
+-- | Property specifies a grid item's start position within the grid column.
+gridColumnStart :: ToGridLine a => a -> Css
+gridColumnStart x = key "grid-column-start" (toGridLine x)
+
+-- | Property specifies a grid item's end position within the grid column.
+gridColumnEnd :: ToGridLine a => a -> Css
+gridColumnEnd x = key "grid-column-end" (toGridLine x)
+
+-- | Property shorthand specifies a grid item's size and location
+-- within a grid row.
+gridRow :: ToGridLines2 a => a -> Css
+gridRow x = key "grid-row" (toGridLines2 x)
+
+-- | Property specifies a grid item's start position within the grid row.
+gridRowStart :: ToGridLine a => a -> Css
+gridRowStart x = key "grid-row-start" (toGridLine x)
+
+-- | Property specifies a grid item's end position within the grid row.
+gridRowEnd :: ToGridLine a => a -> Css
+gridRowEnd x = key "grid-row-end" (toGridLine x)
+
+class Slash a r | a -> r where
+  -- | CSS equivalent /.
+  -- Separates `GridLine` values.
+  (//) :: ToGridLine b => a -> b -> r
+
+instance Slash GridLine TwoGridLines where
+  x // y = TwoGridLines x (toGridLine y)
+
+instance Slash Integer TwoGridLines where
+  x // y = TwoGridLines (toGridLine x) (toGridLine y)
+
+instance Slash String TwoGridLines where
+  x // y = TwoGridLines (toGridLine x) (toGridLine y)
+
+instance Slash (String, Integer) TwoGridLines where
+  x // y = TwoGridLines (toGridLine x) (toGridLine y)
+
+instance Slash TwoGridLines ThreeGridLines where
+  (TwoGridLines xx xy) // y = ThreeGridLines xx xy (toGridLine y)
+
+instance Slash ThreeGridLines FourGridLines where
+  (ThreeGridLines xx xy xz) // y = FourGridLines xx xy xz (toGridLine y)
+
+-- | Keyword indicating that the property contributes nothing to the grid item's
+-- placement.
+instance Com.Auto GridLine where
+  auto = Auto
+
+class ToSpan a where
+
+  -- | Contributes to the grid item's placement.
+  span_ :: a -> GridLine
+
+instance ToSpan Integer where
+
+  -- | Contributes the nth grid line to the grid item's placement.
+  span_ x = Span Nothing (Just x)
+
+instance ToSpan String where
+
+  -- | One line from the provided name is counted.
+  span_ x = Span (Just x) Nothing
+
+instance ToSpan (String, Integer) where
+
+  -- | Nth lines from the provided name are counted.
+  span_ (x, y) = Span (Just x) (Just y)
+
+-- | Keyword inherit applied to a `GridLine`.
+instance Com.Inherit GridLine where
+  inherit = Inherit
+
+-- | Keyword initial applied to a `GridLine`.
+instance Com.Initial GridLine where
+  initial = Initial
+
+-- | Keyword unset applied to a `GridLine`.
+instance Com.Unset GridLine where
+  unset = Unset
+
+-- | Grid line value.
+data GridLine =
+    Auto
+  | Inherit
+  | Initial
+  | Unset
+  | Coordinate Integer
+  | CustomIndent String (Maybe Integer)
+  | Span (Maybe String) (Maybe Integer)
+  deriving (Eq, Show)
+
+class ToGridLine a where
+  toGridLine :: a -> GridLine
+
+instance ToGridLine GridLine where
+  toGridLine = id
+
+instance ToGridLine Integer where
+  toGridLine = Coordinate
+
+instance ToGridLine String where
+  toGridLine x = CustomIndent x Nothing
+
+instance ToGridLine (String, Integer) where
+  toGridLine (x, y) = CustomIndent x (Just y)
+
+-- | One or two `GridLine` values.
+data GridLines2 =
+    One2 OneGridLine
+  | Two2 TwoGridLines
+
+-- | One, two, three or four `GridLine` values.
+data GridLines4 =
+    One OneGridLine
+  | Two TwoGridLines
+  | Three ThreeGridLines
+  | Four FourGridLines
+
+-- | One `GridLine` value
+newtype OneGridLine = OneGridLine GridLine
+
+-- | Two `GridLine` values.
+data TwoGridLines = TwoGridLines GridLine GridLine
+
+-- | Three `GridLine` values.
+data ThreeGridLines = ThreeGridLines GridLine GridLine GridLine
+
+-- | Four `GridLine` values.
+data FourGridLines = FourGridLines GridLine GridLine GridLine GridLine
+
+instance Val GridLine where
+  value Auto               = "auto"
+  value Inherit            = "inherit"
+  value Initial            = "initial"
+  value Unset              = "unset"
+  value (Coordinate x)     = value x
+  value (CustomIndent x y) = value $ T.pack x <> foldMap ((" " <>) . tshow) y
+  value (Span x y) =
+    value $ "span" <> foldMap ((" " <>) . T.pack) x <> foldMap ((" " <>) . tshow) y
+
+-- | Convert a value to `GridLines2` (one or two `GridLine`).
+class ToGridLines2 a where
+  toGridLines2 :: a -> GridLines2
+
+instance ToGridLines2 GridLines2 where
+  toGridLines2 = id
+
+instance ToGridLines2 GridLine where
+  toGridLines2 = One2 . OneGridLine
+
+instance ToGridLines2 OneGridLine where
+  toGridLines2 = One2
+
+instance ToGridLines2 TwoGridLines where
+  toGridLines2 = Two2
+
+instance ToGridLines2 Integer where
+  toGridLines2 = toGridLines2 . toGridLine
+
+instance ToGridLines2 String where
+  toGridLines2 = toGridLines2 . toGridLine
+
+instance ToGridLines2 (String, Integer) where
+  toGridLines2 = toGridLines2 . toGridLine
+
+-- | Convert a value to `GridLines4` (one, two, three or four `GridLine`).
+class ToGridLines4 a where
+  toGridLines :: a -> GridLines4
+
+instance ToGridLines4 GridLines4 where
+  toGridLines = id
+
+instance ToGridLines4 GridLine where
+  toGridLines = One . OneGridLine
+
+instance ToGridLines4 OneGridLine where
+  toGridLines = One
+
+instance ToGridLines4 TwoGridLines where
+  toGridLines = Two
+
+instance ToGridLines4 ThreeGridLines where
+  toGridLines = Three
+
+instance ToGridLines4 FourGridLines where
+  toGridLines = Four
+
+instance ToGridLines4 Integer where
+  toGridLines = toGridLines . toGridLine
+
+instance ToGridLines4 String where
+  toGridLines = toGridLines . toGridLine
+
+instance ToGridLines4 (String, Integer) where
+  toGridLines = toGridLines . toGridLine
+
+instance Val OneGridLine where
+  value (OneGridLine x) = value x
+
+instance Val TwoGridLines where
+  value (TwoGridLines x y) =
+    value x <> value (" / " :: Text) <> value y
+
+instance Val ThreeGridLines where
+  value (ThreeGridLines x y z) =
+       value x
+    <> value (" / " :: Text) <> value y
+    <> value (" / " :: Text) <> value z
+
+instance Val FourGridLines where
+  value (FourGridLines xx xy xz yx) =
+       value xx
+    <> value (" / " :: Text) <> value xy
+    <> value (" / " :: Text) <> value xz
+    <> value (" / " :: Text) <> value yx
+
+instance Val GridLines2 where
+  value (One2 x) = value x
+  value (Two2 x) = value x
+
+instance Val GridLines4 where
+  value (One x)   = value x
+  value (Two x)   = value x
+  value (Three x) = value x
+  value (Four x)  = value x
+
+-- | Utility function to show Text instead of String.
+tshow :: Show a => a -> Text
+tshow = T.pack . show

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -18,15 +18,12 @@ module Clay.Grid
     -- $sizeAndLocationIntro
 
     -- ** Data types and type classes
-  , GridLine (..)
+  , GridLine
   , ToGridLine
-  , toGridLine
-  , GridLines2 (..)
+  , GridLines2
   , ToGridLines2
-  , toGridLines2
-  , GridLines4 (..)
+  , GridLines4
   , ToGridLines4
-  , toGridLines4
   , OneGridLine
   , TwoGridLines
   , ThreeGridLines
@@ -128,9 +125,8 @@ gridTemplateColumns = key "grid-template-columns" . noCommas
 -- For example, @grid-line@ is used instead of 'GridLine' as a the argument
 -- might be provided as a 'GridLine' but also as an 'Integer', 'String', etc.
 --
--- #pragma#
---
 -- == Pragma
+-- #pragma#
 -- If you want to avoid specifying the types of the arguments, enable
 -- the @ExtendedDefaultRules@ GHC language pragma as well as the
 -- @-Wno-type-defaults@ GHC option to avoid compilation warnings.
@@ -166,9 +162,6 @@ gridTemplateColumns = key "grid-template-columns" . noCommas
 -- | A @grid-line@ value.
 --
 -- A @grid-line@ value specifies a size and location in a grid.
---
--- __NOTE:__ although you can use the below constructors, it's also possible
--- to use a closer CSS syntax taking advantage of the 'ToGridLine' instances.
 data GridLine
 
   -- | 'Integer' value.
@@ -231,9 +224,6 @@ instance ToGridLine (String, Integer) where
   toGridLine (x, y) = toGridLine (CustomIdentGrid $ T.pack x, y)
 
 -- | One or two @grid-line@ values.
---
--- __NOTE:__ although you can use the below constructors, it's also possible
--- to use a closer CSS syntax using the 'ToGridLines2' instances.
 data GridLines2
     -- | One @grid-line@ value.
   = One2 OneGridLine
@@ -288,9 +278,6 @@ instance ToGridLines2 (String, Integer) where
   toGridLines2 = toGridLines2 . toGridLine
 
 -- | One, two, three or four @grid-line@ values.
---
--- __NOTE:__ although you can use the below constructors, it's also possible
--- to use a closer CSS syntax using the 'ToGridLines4' instances.
 data GridLines4
 
     -- | One @grid-line@ value.

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -209,7 +209,7 @@ instance ToGridLine CustomIdentGrid where
 
 -- | @custom-ident@ value.
 instance ToGridLine String where
-  toGridLine = toGridLine . CustomIdentGrid . T.pack
+  toGridLine = toGridLine . partialMkCustomIdentGrid . T.pack
 
 -- | Both @custom-ident@ and `Integer` values, provided as a pair.
 --
@@ -221,7 +221,7 @@ instance ToGridLine (CustomIdentGrid, Integer) where
 --
 -- __NOTE:__ 'Integer' value of 0 is invalid.
 instance ToGridLine (String, Integer) where
-  toGridLine (x, y) = toGridLine (CustomIdentGrid $ T.pack x, y)
+  toGridLine (x, y) = toGridLine (partialMkCustomIdentGrid $ T.pack x, y)
 
 -- | One or two @grid-line@ values.
 data GridLines2
@@ -624,13 +624,13 @@ instance ToSpan Integer where
 
 -- | One line from the provided name is counted.
 instance ToSpan String where
-  span_ x = Span (Just . CustomIdentGrid $ T.pack x) Nothing
+  span_ x = Span (Just . partialMkCustomIdentGrid $ T.pack x) Nothing
 
 -- | Nth lines from the provided name are counted.
 --
 -- __NOTE:__ negative 'Integer' or 0 values are invalid.
 instance ToSpan (String, Integer) where
-  span_ (x, y) = Span (Just . CustomIdentGrid $ T.pack x) (Just y)
+  span_ (x, y) = Span (Just . partialMkCustomIdentGrid $ T.pack x) (Just y)
 
 -- | Keyword indicating that the property contributes nothing to the grid item's
 -- placement.

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -163,6 +163,11 @@ gridTemplateColumns = key "grid-template-columns" . noCommas
 -- | A @grid-line@ value.
 --
 -- A @grid-line@ value specifies a size and location in a grid.
+--
+-- === __Note__
+-- To know more about @grid-line@ value, see for example the documentation of
+-- the [grid-row-start](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-row-start)
+-- CSS property.
 data GridLine
 
   -- | 'Integer' value.

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -199,57 +199,57 @@ instance ToGridLines2 (String, Integer) where
 data GridLines4
 
     -- | One `grid-line` value.
-  = One OneGridLine
+  = One4 OneGridLine
 
     -- | Two `grid-line` values.
-  | Two TwoGridLines
+  | Two4 TwoGridLines
 
     -- | Three `grid-line` values.
-  | Three ThreeGridLines
+  | Three4 ThreeGridLines
 
     -- | Four `grid-line` values.
-  | Four FourGridLines
+  | Four4 FourGridLines
 
 class ToGridLines4 a where
   -- | Convert the provided type to 'GridLines4'
   -- (one, two, three or four `grid-line` values).
-  toGridLines :: a -> GridLines4
+  toGridLines4 :: a -> GridLines4
 
 instance ToGridLines4 GridLine where
   -- | One `grid-line` value.
-  toGridLines = One . OneGridLine
+  toGridLines4 = One4 . OneGridLine
 
 instance ToGridLines4 OneGridLine where
   -- | One `grid-line` value.
-  toGridLines = One
+  toGridLines4 = One4
 
 instance ToGridLines4 TwoGridLines where
   -- | Two `grid-line` values.
-  toGridLines = Two
+  toGridLines4 = Two4
 
 instance ToGridLines4 ThreeGridLines where
   -- | Three `grid-line` values.
-  toGridLines = Three
+  toGridLines4 = Three4
 
 instance ToGridLines4 FourGridLines where
   -- | Four `grid-line` values.
-  toGridLines = Four
+  toGridLines4 = Four4
 
 instance ToGridLines4 GridLines4 where
   -- | One, two, three or four `grid-line` values.
-  toGridLines = id
+  toGridLines4 = id
 
 instance ToGridLines4 Integer where
   -- | One 'Integer' value.
-  toGridLines = toGridLines . toGridLine
+  toGridLines4 = toGridLines4 . toGridLine
 
 instance ToGridLines4 String where
   -- | One `custom-ident` value.
-  toGridLines = toGridLines . toGridLine
+  toGridLines4 = toGridLines4 . toGridLine
 
 instance ToGridLines4 (String, Integer) where
   -- | One time both a `custom-ident` and 'Integer' values, provided as a pair.
-  toGridLines = toGridLines . toGridLine
+  toGridLines4 = toGridLines4 . toGridLine
 
 -- | One 'GridLine' value.
 newtype OneGridLine = OneGridLine GridLine
@@ -436,10 +436,10 @@ instance Val GridLines2 where
   value (Two2 x) = value x
 
 instance Val GridLines4 where
-  value (One x)   = value x
-  value (Two x)   = value x
-  value (Three x) = value x
-  value (Four x)  = value x
+  value (One4 x)   = value x
+  value (Two4 x)   = value x
+  value (Three4 x) = value x
+  value (Four4 x)  = value x
 
 -- | Private partial function checking a 'GridLine'.
 --
@@ -517,11 +517,11 @@ partialToGridLines2 x = partialGridLine' gridLines
 partialToGridLines4 :: ToGridLines4 a => a -> GridLines4
 partialToGridLines4 x = partialGridLine' gridLines
   where
-    gridLines = toGridLines x
-    partialGridLine' (One gl)   = One (partialCheckOneGridLine gl)
-    partialGridLine' (Two gl)   = Two (partialCheckTwoGridLines gl)
-    partialGridLine' (Three gl) = Three (partialCheckThreeGridLines gl)
-    partialGridLine' (Four gl)  = Four (partialCheckFourGridLines gl)
+    gridLines = toGridLines4 x
+    partialGridLine' (One4 gl)   = One4 (partialCheckOneGridLine gl)
+    partialGridLine' (Two4 gl)   = Two4 (partialCheckTwoGridLines gl)
+    partialGridLine' (Three4 gl) = Three4 (partialCheckThreeGridLines gl)
+    partialGridLine' (Four4 gl)  = Four4 (partialCheckFourGridLines gl)
 
 -- | Private utility function to show 'Text' instead of 'String'.
 tshow :: Show a => a -> Text

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -5,52 +5,17 @@
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
 -- | Partial implementation of <https://alligator.io/css/css-grid-layout-grid-areas grid area CSS API>.
---
--- For instance, you want to generate the following CSS:
---
--- @
--- .grid1 {
---   display: grid;
---   width: max-content;
--- }
---
--- .grid3 {
---   display: grid;
---   width: max-content;
--- }
---
--- \@media (min-width: 40.0rem) {
---   .grid3 {
---     display: grid;
---     grid-template-columns: 1fr 1fr 1fr;
---     grid-gap: 1rem;
---     width: max-content;
---   }
--- }
--- @
---
--- The corresponding clay code:
---
--- @
---  ".grid1" ? do
---    display grid
---    width maxContent
---  ".grid3" ? do
---    display grid
---    width maxContent
---  query M.screen [M.minWidth (rem 40)] $ ".grid3" ? do
---    display grid
---    gridTemplateColumns [fr 1, fr 1, fr 1]
---    gridGap $ rem 1
---    width maxContent
--- @
 module Clay.Grid
 (
     -- * Grid
+    --
+    -- $gridIntro
     gridGap
   , gridTemplateColumns
 
     -- * Size and location
+    --
+    -- $sizeAndLocationIntro
 
     -- ** Data types and type classes
   , GridLine (..)
@@ -93,6 +58,48 @@ import           Data.Text (Text)
 import qualified Data.Text as T
 import           Prelude
 
+-- $gridIntro
+-- @grid-gap@ and @grid-template@ CSS properties.
+--
+-- For instance, you want to generate the following CSS:
+--
+-- @
+-- .grid1 {
+--   display: grid;
+--   width: max-content;
+-- }
+--
+-- .grid3 {
+--   display: grid;
+--   width: max-content;
+-- }
+--
+-- \@media (min-width: 40.0rem) {
+--   .grid3 {
+--     display: grid;
+--     grid-template-columns: 1fr 1fr 1fr;
+--     grid-gap: 1rem;
+--     width: max-content;
+--   }
+-- }
+-- @
+--
+-- The corresponding clay code:
+--
+-- @
+--  ".grid1" ? do
+--    display grid
+--    width maxContent
+--  ".grid3" ? do
+--    display grid
+--    width maxContent
+--  query M.screen [M.minWidth (rem 40)] $ ".grid3" ? do
+--    display grid
+--    gridTemplateColumns [fr 1, fr 1, fr 1]
+--    gridGap $ rem 1
+--    width maxContent
+-- @
+
 -- | Property sets the gaps (gutters) between rows and columns.
 gridGap :: Size a -> Css
 gridGap = key "grid-gap"
@@ -101,27 +108,67 @@ gridGap = key "grid-gap"
 gridTemplateColumns :: [Size a] -> Css
 gridTemplateColumns = key "grid-template-columns" . noCommas
 
+-- $sizeAndLocationIntro
+--
+-- == CSS documentation
+-- The below functions are based on
+-- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS)
+-- CSS documentation.
+--
+-- #pragma#
+--
+-- == Pragma
+-- If you want to avoid specifying the types of the arguments, enable
+-- the @ExtendedDefaultRules@ GHC language pragma as well as the
+-- @-Wno-type-defaults@ GHC option to avoid compilation warnings.
+--
+-- @
+-- {-# LANGUAGE ExtendedDefaultRules #-}
+-- {-# OPTIONS_GHC -Wno-type-defaults #-}
+-- @
+--
+-- With the above enabled, you can for example write:
+--
+-- >> gridRowStart 2
+--
+-- >> gridRowStart "somegridarea"
+--
+-- If you do not enable those, then you must write:
+--
+-- >> gridRowStart (2 :: Integer)
+--
+-- >> gridRowStart ("somegridarea" :: String)
+--
+-- If you decide to enable the above, it is advisable to have your Clay
+-- CSS code in its own module, so the behaviour of the rest of your code
+-- is not affected.
+--
+-- == Examples
+-- Examples are provided through the documentation for the various functions.
+-- Further examples can be found in the source code of the test suite
+-- in the GridSpec.hs module.
+
 -- | A @grid-line@ value.
 --
 -- A @grid-line@ value specifies a size and location in a grid.
 --
--- NOTE: although you can use the below constructors, it's also possible
+-- __NOTE:__ although you can use the below constructors, it's also possible
 -- to use a closer CSS syntax taking advantage of the 'ToGridLine' instances.
 data GridLine
 
   -- | 'Integer' value.
   --
-  -- NOTE: 'Integer' value of 0 is invalid.
+  -- __NOTE:__ 'Integer' value of 0 is invalid.
   = Coordinate Integer
 
   -- | @custom-ident@ with an optional 'Integer' value.
   --
-  -- NOTE: 'Integer' value of 0 is invalid.
+  -- __NOTE:__ 'Integer' value of 0 is invalid.
   | CustomIndent String (Maybe Integer)
 
   -- | @span@ CSS keyword with an optional @custom-ident@ and/or 'Integer' value.
   --
-  -- NOTE: negative 'Integer' or 0 are invalid.
+  -- __NOTE:__ negative 'Integer' or 0 are invalid.
   | Span (Maybe String) (Maybe Integer)
 
   -- | @auto@ CSS keyword.
@@ -145,7 +192,7 @@ instance ToGridLine GridLine where
   toGridLine = id
 
 instance ToGridLine Integer where
-  -- | NOTE: 'Integer' value of 0 is invalid.
+  -- | __NOTE:__ 'Integer' value of 0 is invalid.
   toGridLine = Coordinate
 
 -- | @custom-ident@ value.
@@ -154,13 +201,13 @@ instance ToGridLine String where
 
 -- | Both @custom-ident@ and `Integer` values, provided as a pair.
 --
--- NOTE: 'Integer' value of 0 is invalid.
+-- __NOTE:__ 'Integer' value of 0 is invalid.
 instance ToGridLine (String, Integer) where
   toGridLine (x, y) = CustomIndent x (Just y)
 
 -- | One or two @grid-line@ values.
 --
--- NOTE: although you can use the below constructors, it's also possible
+-- __NOTE:__ although you can use the below constructors, it's also possible
 -- to use a closer CSS syntax using the 'ToGridLines2' instances.
 data GridLines2
     -- | One @grid-line@ value.
@@ -191,7 +238,7 @@ instance ToGridLines2 GridLines2 where
 
 -- | One 'Integer' value.
 --
--- NOTE: 'Integer' value of 0 is invalid.
+-- __NOTE:__ 'Integer' value of 0 is invalid.
 instance ToGridLines2 Integer where
   toGridLines2 = toGridLines2 . toGridLine
 
@@ -201,13 +248,13 @@ instance ToGridLines2 String where
 
 -- | One time both a @custom-ident@ and 'Integer' values, provided as a pair.
 --
--- NOTE: 'Integer' value of 0 is invalid.
+-- __NOTE:__ 'Integer' value of 0 is invalid.
 instance ToGridLines2 (String, Integer) where
   toGridLines2 = toGridLines2 . toGridLine
 
 -- | One, two, three or four @grid-line@ values.
 --
--- NOTE: although you can use the below constructors, it's also possible
+-- __NOTE:__ although you can use the below constructors, it's also possible
 -- to use a closer CSS syntax using the 'ToGridLines4' instances.
 data GridLines4
 
@@ -278,7 +325,7 @@ data FourGridLines = FourGridLines GridLine GridLine GridLine GridLine
 
 -- $invalidValues
 --
--- #Partial
+-- #partial#
 -- The below functions are partial. They will raise an error if
 -- provided with a @grid-line@ value which is:
 --
@@ -294,34 +341,78 @@ data FourGridLines = FourGridLines GridLine GridLine GridLine GridLine
 -- One to four @grid-line@ values can be specified.
 -- Grid-line values must be separated by a '(//)' operator.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
 --
 -- ==== __Examples__
 --
--- >>> gridArea 3
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
 --
--- >>> gridArea2 $ 2 // "nav"
+-- > gridArea (auto :: GridLine)
 --
--- >>> gridArea $ ("nav", 2) // span_ 3 // 4
+-- > gridArea "somegridarea"
+--
+-- > gridArea $ ("somegridarea", 4) // ("someothergridarea", 2)
+--
+-- > gridArea $ 1 // 3 // 4
 gridArea :: ToGridLines4 a => a -> Css
 gridArea x = key "grid-area" (partialToGridLines4 x)
 
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid column.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
+--
+-- ==== __Examples__
+--
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
+--
+-- > gridColumn (auto :: GridLine)
+--
+-- > gridColumn $ span_ 3
+--
+-- > gridColumn $ span_ ("somegridarea", 5)
+--
+-- > gridColumn $ span_ 3 // 6
 gridColumn :: ToGridLines2 a => a -> Css
 gridColumn x = key "grid-column" (partialToGridLines2 x)
 
 -- | Property specifies a grid item's start position within the grid column.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
+--
+-- ==== __Examples__
+--
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
+--
+-- > gridColumnStart (inherit :: GridLine)
+--
+-- > gridColumnStart 2
+--
+-- > gridColumnStart ("somegridarea", 4)
+--
+-- > gridColumnStart $ span_ ("somegridarea", 5)
 gridColumnStart :: ToGridLine a => a -> Css
 gridColumnStart x = key "grid-column-start" (partialToGridLine x)
 
 -- | Property specifies a grid item's end position within the grid column.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
+--
+-- ==== __Examples__
+--
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
+--
+-- > gridColumnEnd (initial :: GridLine)
+--
+-- > gridColumnEnd 2
+--
+-- > gridColumnEnd "somegridarea"
+--
+-- > gridColumnEnd $ span_ "somegridarea"
 gridColumnEnd :: ToGridLine a => a -> Css
 gridColumnEnd x = key "grid-column-end" (partialToGridLine x)
 
@@ -331,25 +422,58 @@ gridColumnEnd x = key "grid-column-end" (partialToGridLine x)
 -- One or two @grid-line@ values can be specified.
 -- @grid-line@ values must be separated by a '(//)' operator.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
 --
 -- ==== __Examples__
 --
--- >>> gridRow "nav"
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
 --
--- >>> gridRow $ 3 // span_ 2
+-- > gridRow (unset :: GridLine)
+--
+-- > gridRow $ span_ 3
+--
+-- > gridRow $ span_ 3 // 6
+--
+-- > gridRow $ span_ ("somegridarea", 5) // span_ 2
 gridRow :: ToGridLines2 a => a -> Css
 gridRow x = key "grid-row" (partialToGridLines2 x)
 
 -- | Property specifies a grid item's start position within the grid row.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
+--
+-- ==== __Examples__
+--
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
+--
+-- > gridRowStart (initial :: GridLine)
+--
+-- > gridRowStart (-2)
+--
+-- > gridRowStart $ span_ "somegridarea"
+--
+-- > gridRowStart "somegridarea"
 gridRowStart :: ToGridLine a => a -> Css
 gridRowStart x = key "grid-row-start" (partialToGridLine x)
 
 -- | Property specifies a grid item's end position within the grid row.
 --
--- WARNING: this function is partial. See above "Clay.Grid#Partial".
+-- __WARNING:__ this function is partial. See above "Clay.Grid#partial".
+--
+-- ==== __Examples__
+--
+-- The below examples assume that the @ExtendedDefaultRules@ GHC language
+-- pragma is enabled. See above "Clay.Grid#pragma".
+--
+-- > gridRowEnd (auto :: GridLine)
+--
+-- > gridRowEnd (-2)
+--
+-- > gridRowEnd ("somegridarea", 4)
+--
+-- > gridRowEnd $ span_ 3
 gridRowEnd :: ToGridLine a => a -> Css
 gridRowEnd x = key "grid-row-end" (partialToGridLine x)
 
@@ -383,7 +507,7 @@ class ToSpan a where
 
 -- | Contributes the nth grid line to the grid item's placement.
 --
--- NOTE: negative 'Integer' or 0 values are invalid.
+-- __NOTE:__ negative 'Integer' or 0 values are invalid.
 instance ToSpan Integer where
   span_ x = Span Nothing (Just x)
 
@@ -393,7 +517,7 @@ instance ToSpan String where
 
 -- | Nth lines from the provided name are counted.
 --
--- NOTE: negative 'Integer' or 0 values are invalid.
+-- __NOTE:__ negative 'Integer' or 0 values are invalid.
 instance ToSpan (String, Integer) where
   span_ (x, y) = Span (Just x) (Just y)
 

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -439,6 +439,7 @@ partialMkCustomIdentGrid txt = checkText
 -- * a 'span_' function provided with an 'Integer' value of 0 or negative
 -- * a 'span_' function provided with a pair value with
 -- an 'Integer' component of 0 or negative.
+-- * an invalid @custom-ident@ value, see 'partialMkCustomIdentGrid'.
 
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid.

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ExtendedDefaultRules #-}
-{-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_GHC -Wno-type-defaults #-}
 
 -- | Partial implementation of <https://alligator.io/css/css-grid-layout-grid-areas grid area CSS API>.
@@ -46,9 +45,18 @@
 --    width maxContent
 -- @
 module Clay.Grid
-(   -- * Style properties.
+(
+    -- * Grid
     gridGap
   , gridTemplateColumns
+
+    -- * Size and location
+
+    -- ** Data types and type classes
+  , GridLine (..)
+  , ToGridLine
+
+    -- ** Style properties
   , gridArea
   , gridColumn
   , gridColumnStart
@@ -57,7 +65,7 @@ module Clay.Grid
   , gridRowStart
   , gridRowEnd
 
-    -- * Keywords
+    -- ** Keywords
   , (//)
   , span_
 )
@@ -79,40 +87,259 @@ gridGap = key "grid-gap"
 gridTemplateColumns :: [Size a] -> Css
 gridTemplateColumns = key "grid-template-columns" . noCommas
 
+-- | A `grid-line` value.
+--
+-- A grid-line value specifies a size and location in a grid.
+-- the following are invalid:
+--
+-- NOTE: although you can use the below constructors, it's also possible
+-- to use a closer CSS syntax taking advantage of the 'ToGridLine' instances.
+data GridLine
+
+  -- | 'Integer' value.
+  --
+  -- NOTE: 'Integer' value of 0 is invalid.
+  = Coordinate Integer
+
+  -- | `custom-ident` with an optional 'Integer' value.
+  --
+  -- NOTE: 'Integer' value of 0 is invalid.
+  | CustomIndent String (Maybe Integer)
+
+  -- | `span` CSS keyword with an optional `custom-ident` and/or 'Integer' value.
+  --
+  -- NOTE: negative 'Integer' or 0 are invalid.
+  | Span (Maybe String) (Maybe Integer)
+
+  -- | `auto` CSS keyword.
+  | Auto
+
+  -- | `inherit` CSS keyword.
+  | Inherit
+
+  -- | `initial` CSS keyword.
+  | Initial
+
+  -- | `unset` CSS keyword.
+  | Unset
+  deriving (Eq, Show)
+
+class ToGridLine a where
+  -- | Convert the provided type to a 'GridLine'.
+  toGridLine :: a -> GridLine
+
+instance ToGridLine GridLine where
+  toGridLine = id
+
+instance ToGridLine Integer where
+  -- | NOTE: 'Integer' value of 0 is invalid.
+  toGridLine = Coordinate
+
+-- | `custom-ident` value.
+instance ToGridLine String where
+  toGridLine x = CustomIndent x Nothing
+
+-- | Both `custom-ident` and `Integer` values, provided as a pair.
+--
+-- NOTE: 'Integer' value of 0 is invalid.
+instance ToGridLine (String, Integer) where
+  toGridLine (x, y) = CustomIndent x (Just y)
+
+-- | One or two `grid-line` values.
+--
+-- NOTE: although you can use the below constructors, it's also possible
+-- to use a closer CSS syntax using the 'ToGridLines2' instances.
+data GridLines2
+    -- | One `grid-line` value.
+  = One2 OneGridLine
+    -- | Two `grid-line` values.
+  | Two2 TwoGridLines
+
+class ToGridLines2 a where
+
+  -- | Convert the provided type to 'GridLines2' (one or two `grid-line` values).
+  toGridLines2 :: a -> GridLines2
+
+instance ToGridLines2 GridLine where
+  -- | One `grid-line` value.
+  toGridLines2 = One2 . OneGridLine
+
+instance ToGridLines2 OneGridLine where
+  -- | One `grid-line` value.
+  toGridLines2 = One2
+
+instance ToGridLines2 TwoGridLines where
+  -- | Two `grid-line` values.
+  toGridLines2 = Two2
+
+instance ToGridLines2 GridLines2 where
+  -- | One or two `grid-line` values.
+  toGridLines2 = id
+
+instance ToGridLines2 Integer where
+  -- | One 'Integer' value.
+  --
+  -- NOTE: 'Integer' value of 0 is invalid.
+  toGridLines2 = toGridLines2 . toGridLine
+
+instance ToGridLines2 String where
+  -- | One `custom-ident` value.
+  toGridLines2 = toGridLines2 . toGridLine
+
+instance ToGridLines2 (String, Integer) where
+  -- | One time both a `custom-ident` and 'Integer' values, provided as a pair.
+  --
+  -- NOTE: 'Integer' value of 0 is invalid.
+  toGridLines2 = toGridLines2 . toGridLine
+
+-- | One, two, three or four `grid-line` values.
+--
+-- NOTE: although you can use the below constructors, it's also possible
+-- to use a closer CSS syntax using the 'ToGridLines4' instances.
+data GridLines4
+    -- | One `grid-line` value.
+  = One OneGridLine
+    -- | Two `grid-line` values.
+  | Two TwoGridLines
+    -- | Three `grid-line` values.
+  | Three ThreeGridLines
+    -- | Four `grid-line` values.
+  | Four FourGridLines
+
+class ToGridLines4 a where
+  -- | Convert the provided type to 'GridLines4'
+  -- (one, two, three or four `grid-line` values).
+  toGridLines :: a -> GridLines4
+
+instance ToGridLines4 GridLine where
+  -- | One `grid-line` value.
+  toGridLines = One . OneGridLine
+
+instance ToGridLines4 OneGridLine where
+  -- | One `grid-line` value.
+  toGridLines = One
+
+instance ToGridLines4 TwoGridLines where
+  -- | Two `grid-line` values.
+  toGridLines = Two
+
+instance ToGridLines4 ThreeGridLines where
+  -- | Three `grid-line` values.
+  toGridLines = Three
+
+instance ToGridLines4 FourGridLines where
+  -- | Four `grid-line` values.
+  toGridLines = Four
+
+instance ToGridLines4 GridLines4 where
+  -- | One, two, three or four `grid-line` values.
+  toGridLines = id
+
+instance ToGridLines4 Integer where
+  -- | One 'Integer' value.
+  toGridLines = toGridLines . toGridLine
+
+instance ToGridLines4 String where
+  -- | One `custom-ident` value.
+  toGridLines = toGridLines . toGridLine
+
+instance ToGridLines4 (String, Integer) where
+  -- | One time both a `custom-ident` and 'Integer' values, provided as a pair.
+  toGridLines = toGridLines . toGridLine
+
+-- | One 'GridLine' value.
+newtype OneGridLine = OneGridLine GridLine
+
+-- | Two 'GridLine' values.
+data TwoGridLines = TwoGridLines GridLine GridLine
+
+-- | Three 'GridLine' values.
+data ThreeGridLines = ThreeGridLines GridLine GridLine GridLine
+
+-- | Four 'GridLine' values.
+data FourGridLines = FourGridLines GridLine GridLine GridLine GridLine
+
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid.
+--
+-- One to four `grid-line` values can be specified.
+-- Grid-line values must be separated by a '(//)' operator.
+--
+-- WARNING: this function is partial. TODO report cases.
+--
+-- ==== __Examples__
+--
+-- >>> gridArea 3
+--
+-- >>> gridArea2 $ 2 // "nav"
+--
+-- >>> gridArea $ ("nav", 2) // span_ 3 // 4
 gridArea :: ToGridLines4 a => a -> Css
 gridArea x = key "grid-area" (toGridLines x)
 
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid column.
+--
+-- TODO write doc.
 gridColumn :: ToGridLines2 a => a -> Css
 gridColumn x = key "grid-column" (toGridLines2 x)
 
 -- | Property specifies a grid item's start position within the grid column.
+--
+-- TODO: write doc.
 gridColumnStart :: ToGridLine a => a -> Css
 gridColumnStart x = key "grid-column-start" (toGridLine x)
 
 -- | Property specifies a grid item's end position within the grid column.
+--
+-- TODO: write doc.
 gridColumnEnd :: ToGridLine a => a -> Css
 gridColumnEnd x = key "grid-column-end" (toGridLine x)
 
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid row.
+--
+-- One or two `grid-line` values can be specified.
+-- `grid-line` values must be separated by a '(//)' operator.
+--
+-- WARNING: this function is partial. TODO provide cases.
+--
+-- ==== __Examples__
+--
+-- >>> gridRow "nav"
+--
+-- >>> gridRow $ 3 // span_ 2
 gridRow :: ToGridLines2 a => a -> Css
 gridRow x = key "grid-row" (toGridLines2 x)
 
 -- | Property specifies a grid item's start position within the grid row.
+--
+-- WARNING: this function is partial, the following are invalid:
+--
+-- - an 'Integer' value of 0
+-- - a pair with an 'Integer' component of value 0
+-- - a 'span_' function provided with an 'Integer' value of 0 or negative
+-- - a 'span_' function provided with a pair value with
+-- an 'Integer' component of 0 or negative.
+-- - a 'GridLine' value representing one of the above.
 gridRowStart :: ToGridLine a => a -> Css
-gridRowStart x = key "grid-row-start" (toGridLine x)
+gridRowStart x = key "grid-row-start" (partialToGridLine x)
 
 -- | Property specifies a grid item's end position within the grid row.
+--
+-- WARNING: this function is partial, the following arguments are invalid:
+-- - an 'Integer' value of 0
+-- - a pair with an 'Integer' component of value 0
+-- - a 'span_' function provided with an 'Integer' value of 0 or negative
+-- - a 'span_' function provided with a pair value with
+-- an 'Integer' component of 0 or negative
+-- - a 'GridLine' value representing one of the above.
 gridRowEnd :: ToGridLine a => a -> Css
-gridRowEnd x = key "grid-row-end" (toGridLine x)
+gridRowEnd x = key "grid-row-end" (partialToGridLine x)
 
 class Slash a r | a -> r where
-  -- | CSS equivalent /.
-  -- Separates `GridLine` values.
+  -- | `/` CSS operator.
+  -- Separates `grid-line` values.
   (//) :: ToGridLine b => a -> b -> r
 
 instance Slash GridLine TwoGridLines where
@@ -133,11 +360,6 @@ instance Slash TwoGridLines ThreeGridLines where
 instance Slash ThreeGridLines FourGridLines where
   (ThreeGridLines xx xy xz) // y = FourGridLines xx xy xz (toGridLine y)
 
--- | Keyword indicating that the property contributes nothing to the grid item's
--- placement.
-instance Com.Auto GridLine where
-  auto = Auto
-
 class ToSpan a where
 
   -- | Contributes to the grid item's placement.
@@ -146,6 +368,8 @@ class ToSpan a where
 instance ToSpan Integer where
 
   -- | Contributes the nth grid line to the grid item's placement.
+  --
+  -- NOTE: negative 'Integer' or 0 values are invalid.
   span_ x = Span Nothing (Just x)
 
 instance ToSpan String where
@@ -156,70 +380,28 @@ instance ToSpan String where
 instance ToSpan (String, Integer) where
 
   -- | Nth lines from the provided name are counted.
+  --
+  -- NOTE: negative 'Integer' or 0 values are invalid.
   span_ (x, y) = Span (Just x) (Just y)
 
--- | Keyword inherit applied to a `GridLine`.
+-- | Keyword indicating that the property contributes nothing to the grid item's
+-- placement.
+instance Com.Auto GridLine where
+  auto = Auto
+
+-- | Keyword `inherit` applied to a 'GridLine'.
 instance Com.Inherit GridLine where
   inherit = Inherit
 
--- | Keyword initial applied to a `GridLine`.
+-- | Keyword `initial` applied to a 'GridLine'.
 instance Com.Initial GridLine where
   initial = Initial
 
--- | Keyword unset applied to a `GridLine`.
+-- | Keyword `unset` applied to a 'GridLine'.
 instance Com.Unset GridLine where
   unset = Unset
 
--- | Grid line value.
-data GridLine =
-    Auto
-  | Inherit
-  | Initial
-  | Unset
-  | Coordinate Integer
-  | CustomIndent String (Maybe Integer)
-  | Span (Maybe String) (Maybe Integer)
-  deriving (Eq, Show)
-
-class ToGridLine a where
-  toGridLine :: a -> GridLine
-
-instance ToGridLine GridLine where
-  toGridLine = id
-
-instance ToGridLine Integer where
-  toGridLine = Coordinate
-
-instance ToGridLine String where
-  toGridLine x = CustomIndent x Nothing
-
-instance ToGridLine (String, Integer) where
-  toGridLine (x, y) = CustomIndent x (Just y)
-
--- | One or two `GridLine` values.
-data GridLines2 =
-    One2 OneGridLine
-  | Two2 TwoGridLines
-
--- | One, two, three or four `GridLine` values.
-data GridLines4 =
-    One OneGridLine
-  | Two TwoGridLines
-  | Three ThreeGridLines
-  | Four FourGridLines
-
--- | One `GridLine` value
-newtype OneGridLine = OneGridLine GridLine
-
--- | Two `GridLine` values.
-data TwoGridLines = TwoGridLines GridLine GridLine
-
--- | Three `GridLine` values.
-data ThreeGridLines = ThreeGridLines GridLine GridLine GridLine
-
--- | Four `GridLine` values.
-data FourGridLines = FourGridLines GridLine GridLine GridLine GridLine
-
+-- | Convertion of 'GridLine' to 'Clay.Property.Value'.
 instance Val GridLine where
   value Auto               = "auto"
   value Inherit            = "inherit"
@@ -229,62 +411,6 @@ instance Val GridLine where
   value (CustomIndent x y) = value $ T.pack x <> foldMap ((" " <>) . tshow) y
   value (Span x y) =
     value $ "span" <> foldMap ((" " <>) . T.pack) x <> foldMap ((" " <>) . tshow) y
-
--- | Convert a value to `GridLines2` (one or two `GridLine`).
-class ToGridLines2 a where
-  toGridLines2 :: a -> GridLines2
-
-instance ToGridLines2 GridLines2 where
-  toGridLines2 = id
-
-instance ToGridLines2 GridLine where
-  toGridLines2 = One2 . OneGridLine
-
-instance ToGridLines2 OneGridLine where
-  toGridLines2 = One2
-
-instance ToGridLines2 TwoGridLines where
-  toGridLines2 = Two2
-
-instance ToGridLines2 Integer where
-  toGridLines2 = toGridLines2 . toGridLine
-
-instance ToGridLines2 String where
-  toGridLines2 = toGridLines2 . toGridLine
-
-instance ToGridLines2 (String, Integer) where
-  toGridLines2 = toGridLines2 . toGridLine
-
--- | Convert a value to `GridLines4` (one, two, three or four `GridLine`).
-class ToGridLines4 a where
-  toGridLines :: a -> GridLines4
-
-instance ToGridLines4 GridLines4 where
-  toGridLines = id
-
-instance ToGridLines4 GridLine where
-  toGridLines = One . OneGridLine
-
-instance ToGridLines4 OneGridLine where
-  toGridLines = One
-
-instance ToGridLines4 TwoGridLines where
-  toGridLines = Two
-
-instance ToGridLines4 ThreeGridLines where
-  toGridLines = Three
-
-instance ToGridLines4 FourGridLines where
-  toGridLines = Four
-
-instance ToGridLines4 Integer where
-  toGridLines = toGridLines . toGridLine
-
-instance ToGridLines4 String where
-  toGridLines = toGridLines . toGridLine
-
-instance ToGridLines4 (String, Integer) where
-  toGridLines = toGridLines . toGridLine
 
 instance Val OneGridLine where
   value (OneGridLine x) = value x
@@ -316,6 +442,22 @@ instance Val GridLines4 where
   value (Three x) = value x
   value (Four x)  = value x
 
--- | Utility function to show Text instead of String.
+-- | Private partial function converting its argument to 'GridLine'.
+--
+-- An error is raised when:
+-- - An 'Integer' value of 0 is provided.
+-- - A negative 'Integer' value is provided for a 'Span' constructor.
+partialToGridLine :: ToGridLine a => a -> GridLine
+partialToGridLine x = case toGridLine x of
+  Coordinate 0            -> errorValue 0
+  CustomIndent _ (Just 0) -> errorValue 0
+  s@(Span _ (Just n))     -> if n < 1
+                             then errorValue n
+                             else s
+  gridLine                -> gridLine
+  where
+    errorValue n = error ("Value " ++ show n ++ " is invalid")
+
+-- | Private utility function to show 'Text' instead of 'String'.
 tshow :: Show a => a -> Text
 tshow = T.pack . show

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -61,6 +61,9 @@ import           Prelude
 -- $gridIntro
 -- @grid-gap@ and @grid-template@ CSS properties.
 --
+-- === Example
+-- For the below CSS code:
+--
 -- @
 -- .grid1 {
 --   display: grid;

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -61,8 +61,6 @@ import           Prelude
 -- $gridIntro
 -- @grid-gap@ and @grid-template@ CSS properties.
 --
--- For instance, you want to generate the following CSS:
---
 -- @
 -- .grid1 {
 --   display: grid;
@@ -84,7 +82,7 @@ import           Prelude
 -- }
 -- @
 --
--- The corresponding clay code:
+-- The corresponding clay code is:
 --
 -- @
 --  ".grid1" ? do
@@ -115,6 +113,14 @@ gridTemplateColumns = key "grid-template-columns" . noCommas
 -- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS)
 -- CSS documentation.
 --
+-- === __Naming note__
+-- In this documentation, as the functions are polymorphic we sometimes
+-- refer to the CSS types as used in the
+-- [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS)
+-- rather than the Haskell types.
+-- For example, @grid-line@ is used instead of 'GridLine' as a the argument
+-- might be provided as a 'GridLine' but also as an 'Integer', 'String', etc.
+--
 -- #pragma#
 --
 -- == Pragma
@@ -127,7 +133,8 @@ gridTemplateColumns = key "grid-template-columns" . noCommas
 -- {-# OPTIONS_GHC -Wno-type-defaults #-}
 -- @
 --
--- With the above enabled, you can for example write:
+-- === __Examples__
+-- With the above enabled, you can write:
 --
 -- >> gridRowStart 2
 --
@@ -139,6 +146,7 @@ gridTemplateColumns = key "grid-template-columns" . noCommas
 --
 -- >> gridRowStart ("somegridarea" :: String)
 --
+-- === __Note__
 -- If you decide to enable the above, it is advisable to have your Clay
 -- CSS code in its own module, so the behaviour of the rest of your code
 -- is not affected.

--- a/src/Clay/Grid.hs
+++ b/src/Clay/Grid.hs
@@ -55,8 +55,22 @@ module Clay.Grid
     -- ** Data types and type classes
   , GridLine (..)
   , ToGridLine
+  , toGridLine
+  , GridLines2 (..)
+  , ToGridLines2
+  , toGridLines2
+  , GridLines4 (..)
+  , ToGridLines4
+  , toGridLines4
+  , OneGridLine
+  , TwoGridLines
+  , ThreeGridLines
+  , FourGridLines
+  , ToSpan
 
     -- ** Style properties
+    --
+    -- $invalidValues
   , gridArea
   , gridColumn
   , gridColumnStart
@@ -77,7 +91,7 @@ import           Clay.Size (Size)
 import           Clay.Stylesheet (Css, key)
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Prelude hiding (span)
+import           Prelude
 
 -- | Property sets the gaps (gutters) between rows and columns.
 gridGap :: Size a -> Css
@@ -87,10 +101,9 @@ gridGap = key "grid-gap"
 gridTemplateColumns :: [Size a] -> Css
 gridTemplateColumns = key "grid-template-columns" . noCommas
 
--- | A `grid-line` value.
+-- | A @grid-line@ value.
 --
--- A grid-line value specifies a size and location in a grid.
--- the following are invalid:
+-- A @grid-line@ value specifies a size and location in a grid.
 --
 -- NOTE: although you can use the below constructors, it's also possible
 -- to use a closer CSS syntax taking advantage of the 'ToGridLine' instances.
@@ -101,26 +114,26 @@ data GridLine
   -- NOTE: 'Integer' value of 0 is invalid.
   = Coordinate Integer
 
-  -- | `custom-ident` with an optional 'Integer' value.
+  -- | @custom-ident@ with an optional 'Integer' value.
   --
   -- NOTE: 'Integer' value of 0 is invalid.
   | CustomIndent String (Maybe Integer)
 
-  -- | `span` CSS keyword with an optional `custom-ident` and/or 'Integer' value.
+  -- | @span@ CSS keyword with an optional @custom-ident@ and/or 'Integer' value.
   --
   -- NOTE: negative 'Integer' or 0 are invalid.
   | Span (Maybe String) (Maybe Integer)
 
-  -- | `auto` CSS keyword.
+  -- | @auto@ CSS keyword.
   | Auto
 
-  -- | `inherit` CSS keyword.
+  -- | @inherit@ CSS keyword.
   | Inherit
 
-  -- | `initial` CSS keyword.
+  -- | @initial@ CSS keyword.
   | Initial
 
-  -- | `unset` CSS keyword.
+  -- | @unset@ CSS keyword.
   | Unset
   deriving (Eq, Show)
 
@@ -135,120 +148,120 @@ instance ToGridLine Integer where
   -- | NOTE: 'Integer' value of 0 is invalid.
   toGridLine = Coordinate
 
--- | `custom-ident` value.
+-- | @custom-ident@ value.
 instance ToGridLine String where
   toGridLine x = CustomIndent x Nothing
 
--- | Both `custom-ident` and `Integer` values, provided as a pair.
+-- | Both @custom-ident@ and `Integer` values, provided as a pair.
 --
 -- NOTE: 'Integer' value of 0 is invalid.
 instance ToGridLine (String, Integer) where
   toGridLine (x, y) = CustomIndent x (Just y)
 
--- | One or two `grid-line` values.
+-- | One or two @grid-line@ values.
 --
 -- NOTE: although you can use the below constructors, it's also possible
 -- to use a closer CSS syntax using the 'ToGridLines2' instances.
 data GridLines2
-    -- | One `grid-line` value.
+    -- | One @grid-line@ value.
   = One2 OneGridLine
-    -- | Two `grid-line` values.
+    -- | Two @grid-line@ values.
   | Two2 TwoGridLines
 
 class ToGridLines2 a where
 
-  -- | Convert the provided type to 'GridLines2' (one or two `grid-line` values).
+  -- | Convert the provided type to 'GridLines2' (one or two @grid-line@ values).
   toGridLines2 :: a -> GridLines2
 
+-- | One @grid-line@ value.
 instance ToGridLines2 GridLine where
-  -- | One `grid-line` value.
   toGridLines2 = One2 . OneGridLine
 
+-- | One @grid-line@ value.
 instance ToGridLines2 OneGridLine where
-  -- | One `grid-line` value.
   toGridLines2 = One2
 
+-- | Two @grid-line@ values.
 instance ToGridLines2 TwoGridLines where
-  -- | Two `grid-line` values.
   toGridLines2 = Two2
 
+-- | One or two @grid-line@ values.
 instance ToGridLines2 GridLines2 where
-  -- | One or two `grid-line` values.
   toGridLines2 = id
 
+-- | One 'Integer' value.
+--
+-- NOTE: 'Integer' value of 0 is invalid.
 instance ToGridLines2 Integer where
-  -- | One 'Integer' value.
-  --
-  -- NOTE: 'Integer' value of 0 is invalid.
   toGridLines2 = toGridLines2 . toGridLine
 
+-- | One @custom-ident@ value.
 instance ToGridLines2 String where
-  -- | One `custom-ident` value.
   toGridLines2 = toGridLines2 . toGridLine
 
+-- | One time both a @custom-ident@ and 'Integer' values, provided as a pair.
+--
+-- NOTE: 'Integer' value of 0 is invalid.
 instance ToGridLines2 (String, Integer) where
-  -- | One time both a `custom-ident` and 'Integer' values, provided as a pair.
-  --
-  -- NOTE: 'Integer' value of 0 is invalid.
   toGridLines2 = toGridLines2 . toGridLine
 
--- | One, two, three or four `grid-line` values.
+-- | One, two, three or four @grid-line@ values.
 --
 -- NOTE: although you can use the below constructors, it's also possible
 -- to use a closer CSS syntax using the 'ToGridLines4' instances.
 data GridLines4
 
-    -- | One `grid-line` value.
+    -- | One @grid-line@ value.
   = One4 OneGridLine
 
-    -- | Two `grid-line` values.
+    -- | Two @grid-line@ values.
   | Two4 TwoGridLines
 
-    -- | Three `grid-line` values.
+    -- | Three @grid-line@ values.
   | Three4 ThreeGridLines
 
-    -- | Four `grid-line` values.
+    -- | Four @grid-line@ values.
   | Four4 FourGridLines
 
 class ToGridLines4 a where
   -- | Convert the provided type to 'GridLines4'
-  -- (one, two, three or four `grid-line` values).
+  -- (one, two, three or four @grid-line@ values).
   toGridLines4 :: a -> GridLines4
 
+-- | One @grid-line@ value.
 instance ToGridLines4 GridLine where
-  -- | One `grid-line` value.
   toGridLines4 = One4 . OneGridLine
 
+-- | One @grid-line@ value.
 instance ToGridLines4 OneGridLine where
-  -- | One `grid-line` value.
   toGridLines4 = One4
 
+-- | Two @grid-line@ values.
 instance ToGridLines4 TwoGridLines where
-  -- | Two `grid-line` values.
   toGridLines4 = Two4
 
+-- | Three @grid-line@ values.
 instance ToGridLines4 ThreeGridLines where
-  -- | Three `grid-line` values.
   toGridLines4 = Three4
 
+-- | Four @grid-line@ values.
 instance ToGridLines4 FourGridLines where
-  -- | Four `grid-line` values.
   toGridLines4 = Four4
 
+-- | One, two, three or four @grid-line@ values.
 instance ToGridLines4 GridLines4 where
-  -- | One, two, three or four `grid-line` values.
   toGridLines4 = id
 
+-- | One 'Integer' value.
 instance ToGridLines4 Integer where
-  -- | One 'Integer' value.
   toGridLines4 = toGridLines4 . toGridLine
 
+-- | One @custom-ident@ value.
 instance ToGridLines4 String where
-  -- | One `custom-ident` value.
   toGridLines4 = toGridLines4 . toGridLine
 
+-- | One time both a @custom-ident@ and 'Integer' values, provided as a pair.
 instance ToGridLines4 (String, Integer) where
-  -- | One time both a `custom-ident` and 'Integer' values, provided as a pair.
   toGridLines4 = toGridLines4 . toGridLine
 
 -- | One 'GridLine' value.
@@ -263,14 +276,25 @@ data ThreeGridLines = ThreeGridLines GridLine GridLine GridLine
 -- | Four 'GridLine' values.
 data FourGridLines = FourGridLines GridLine GridLine GridLine GridLine
 
+-- $invalidValues
+--
+-- #Partial
+-- The below functions are partial. They will raise an error if
+-- provided with a @grid-line@ value which is:
+--
+-- * an 'Integer' value of 0
+-- * a pair with an 'Integer' component of value 0
+-- * a 'span_' function provided with an 'Integer' value of 0 or negative
+-- * a 'span_' function provided with a pair value with
+-- an 'Integer' component of 0 or negative.
+
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid.
 --
--- One to four `grid-line` values can be specified.
+-- One to four @grid-line@ values can be specified.
 -- Grid-line values must be separated by a '(//)' operator.
 --
--- WARNING: this function is partial.
---
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 --
 -- ==== __Examples__
 --
@@ -285,29 +309,29 @@ gridArea x = key "grid-area" (partialToGridLines4 x)
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid column.
 --
--- TODO write doc.
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 gridColumn :: ToGridLines2 a => a -> Css
 gridColumn x = key "grid-column" (partialToGridLines2 x)
 
 -- | Property specifies a grid item's start position within the grid column.
 --
--- TODO: write doc.
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 gridColumnStart :: ToGridLine a => a -> Css
 gridColumnStart x = key "grid-column-start" (partialToGridLine x)
 
 -- | Property specifies a grid item's end position within the grid column.
 --
--- TODO: write doc.
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 gridColumnEnd :: ToGridLine a => a -> Css
 gridColumnEnd x = key "grid-column-end" (partialToGridLine x)
 
 -- | Property shorthand specifies a grid item's size and location
 -- within a grid row.
 --
--- One or two `grid-line` values can be specified.
--- `grid-line` values must be separated by a '(//)' operator.
+-- One or two @grid-line@ values can be specified.
+-- @grid-line@ values must be separated by a '(//)' operator.
 --
--- WARNING: this function is partial, see above documentation.
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 --
 -- ==== __Examples__
 --
@@ -319,26 +343,19 @@ gridRow x = key "grid-row" (partialToGridLines2 x)
 
 -- | Property specifies a grid item's start position within the grid row.
 --
--- WARNING: this function is partial, see above documentation.
--- TODO: move this up in a global comment.
--- - an 'Integer' value of 0
--- - a pair with an 'Integer' component of value 0
--- - a 'span_' function provided with an 'Integer' value of 0 or negative
--- - a 'span_' function provided with a pair value with
--- an 'Integer' component of 0 or negative.
--- - a 'GridLine' value representing one of the above.
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 gridRowStart :: ToGridLine a => a -> Css
 gridRowStart x = key "grid-row-start" (partialToGridLine x)
 
 -- | Property specifies a grid item's end position within the grid row.
 --
--- WARNING: this function is partial, see above documentation.
+-- WARNING: this function is partial. See above "Clay.Grid#Partial".
 gridRowEnd :: ToGridLine a => a -> Css
 gridRowEnd x = key "grid-row-end" (partialToGridLine x)
 
 class Slash a r | a -> r where
   -- | `/` CSS operator.
-  -- Separates `grid-line` values.
+  -- Separates @grid-line@ values.
   (//) :: ToGridLine b => a -> b -> r
 
 instance Slash GridLine TwoGridLines where
@@ -361,26 +378,23 @@ instance Slash ThreeGridLines FourGridLines where
 
 class ToSpan a where
 
-  -- | Contributes to the grid item's placement.
+  -- | @span@ CSS keyword, contributes to the grid item's placement.
   span_ :: a -> GridLine
 
+-- | Contributes the nth grid line to the grid item's placement.
+--
+-- NOTE: negative 'Integer' or 0 values are invalid.
 instance ToSpan Integer where
-
-  -- | Contributes the nth grid line to the grid item's placement.
-  --
-  -- NOTE: negative 'Integer' or 0 values are invalid.
   span_ x = Span Nothing (Just x)
 
+-- | One line from the provided name is counted.
 instance ToSpan String where
-
-  -- | One line from the provided name is counted.
   span_ x = Span (Just x) Nothing
 
+-- | Nth lines from the provided name are counted.
+--
+-- NOTE: negative 'Integer' or 0 values are invalid.
 instance ToSpan (String, Integer) where
-
-  -- | Nth lines from the provided name are counted.
-  --
-  -- NOTE: negative 'Integer' or 0 values are invalid.
   span_ (x, y) = Span (Just x) (Just y)
 
 -- | Keyword indicating that the property contributes nothing to the grid item's

--- a/src/Clay/Text.hs
+++ b/src/Clay/Text.hs
@@ -398,9 +398,9 @@ instance Num HyphenateLimit where
 --
 -- For reference, see
 -- [@hyphenate-limit-chars@](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-limit-chars).
-hyphenateLimitChars
+hyphenateLimitChars ::
   -- | Minimum length of a word which can be hyphenated.
-  :: HyphenateLimit
+     HyphenateLimit
   -- | Minimum number of characters allowed before a break point.
   -> HyphenateLimit
   -- | Minimum number of characters allowed after a break point.

--- a/src/Clay/Text.hs
+++ b/src/Clay/Text.hs
@@ -399,12 +399,9 @@ instance Num HyphenateLimit where
 -- For reference, see
 -- [@hyphenate-limit-chars@](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphenate-limit-chars).
 hyphenateLimitChars ::
-  -- | Minimum length of a word which can be hyphenated.
-     HyphenateLimit
-  -- | Minimum number of characters allowed before a break point.
-  -> HyphenateLimit
-  -- | Minimum number of characters allowed after a break point.
-  -> HyphenateLimit
+     HyphenateLimit -- ^ Minimum length of a word which can be hyphenated.
+  -> HyphenateLimit -- ^ Minimum number of characters allowed before a break point.
+  -> HyphenateLimit -- ^ Minimum number of characters allowed after a break point.
   -> Css
 hyphenateLimitChars word before after =
   key "hyphenate-limit-chars" (word ! before ! after)


### PR DESCRIPTION
Hello,

Following our discussions in [issue 176](https://github.com/sebastiaanvisser/clay/issues/176), here is my pull request for Grid size and position support.
I've also performed some minor corrections to avoid GHC compiler warnings and compilation failures with older version of GHC.

Some notes:

- I've implemented a '//' operator for the CSS '/' operator. However, this operator is used in other CSS properties (background and font are the ones I know of). So, it's not fully coherent with the rest of the library. On the other hand, I find the syntax rather nice and natural (more than using tuples, especially because I already use them when a custom-ident is combined with an Integer).
- There are spaces between the the '/' and its parameters (1 / 2)  which is not removed when rendered in compact form. However, I feel this should more be the job of the compact rendering to remove them (but maybe I'm missing something here)
- To properly implement all the naming rules for the custom-ident is [highly complex](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident) due to the escaping and Unicode rules. It would require a parser such as MegaParsec. RegExp would not really be a good solution, as it would be difficult to return valuable error messages to the user. Adding a dependency for this only purpose is not worth it in my opinion.

Let me know your thoughts.