### PR TITLE
Add support for `aspect-ratio` CSS property.

### DIFF
--- a/spec/Clay/GeometrySpec.hs
+++ b/spec/Clay/GeometrySpec.hs
@@ -1,0 +1,50 @@
+{-#LANGUAGE OverloadedStrings#-}
+
+module Clay.GeometrySpec where
+
+import Clay.Common
+import Clay.Geometry
+import Clay.Render
+import Clay.Stylesheet
+
+import Control.Exception (evaluate)
+import qualified Data.Ratio as R
+import Data.Text.Lazy
+
+import Test.Hspec
+
+compactRender :: Css -> Text
+compactRender css = renderWith compact [] css
+
+spec :: Spec
+spec = do
+  describe "aspect-ratio" $ do
+    it "has ratio" $ do
+      compactRender (aspectRatio (2%1)) `shouldBe` "{aspect-ratio:2/1}"
+      compactRender (aspectRatio (4%3)) `shouldBe` "{aspect-ratio:4/3}"
+      compactRender (aspectRatio (8%6)) `shouldBe` "{aspect-ratio:4/3}"
+
+    it "has rational ratio" $ do
+      compactRender (aspectRatio $ fromRational $ 2 R.% 1) `shouldBe` "{aspect-ratio:2/1}"
+      compactRender (aspectRatio $ fromRational $ 4 R.% 3) `shouldBe` "{aspect-ratio:4/3}"
+      compactRender (aspectRatio $ fromRational $ 8 R.% 6) `shouldBe` "{aspect-ratio:4/3}"
+
+    it "has auto value" $ do
+      compactRender (aspectRatio auto) `shouldBe` "{aspect-ratio:auto}"
+
+    it "has inherit value" $ do
+      compactRender (aspectRatio inherit) `shouldBe` "{aspect-ratio:inherit}"
+
+    it "has initial value" $ do
+      compactRender (aspectRatio initial) `shouldBe` "{aspect-ratio:initial}"
+
+    it "has unset value" $ do
+      compactRender (aspectRatio unset) `shouldBe` "{aspect-ratio:unset}"
+
+    it "has auto value and fallback ratio" $ do
+      compactRender (aspectRatio $ auto `withFallback` (4%3)) `shouldBe` "{aspect-ratio:auto 4/3}"
+      compactRender (aspectRatio $ (4%3) `withFallback` auto) `shouldBe` "{aspect-ratio:4/3 auto}"
+
+    it "does not allow invalid fallbacks" $ do
+      evaluate (compactRender $ aspectRatio $ auto `withFallback` auto) `shouldThrow` anyErrorCall
+      evaluate (compactRender $ aspectRatio $ (4%3) `withFallback` (4%3)) `shouldThrow` anyErrorCall

--- a/spec/Clay/GeometrySpec.hs
+++ b/spec/Clay/GeometrySpec.hs
@@ -1,4 +1,4 @@
-{-#LANGUAGE OverloadedStrings#-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Clay.GeometrySpec where
 

--- a/spec/Clay/GeometrySpec.hs
+++ b/spec/Clay/GeometrySpec.hs
@@ -14,7 +14,7 @@ import Data.Text.Lazy
 import Test.Hspec
 
 compactRender :: Css -> Text
-compactRender css = renderWith compact [] css
+compactRender = renderWith compact []
 
 spec :: Spec
 spec = do
@@ -48,3 +48,6 @@ spec = do
     it "does not allow invalid fallbacks" $ do
       evaluate (compactRender $ aspectRatio $ auto `withFallback` auto) `shouldThrow` anyErrorCall
       evaluate (compactRender $ aspectRatio $ (4%3) `withFallback` (4%3)) `shouldThrow` anyErrorCall
+
+    it "has arbtrary other value" $ do
+      compactRender (aspectRatio $ other "not valid") `shouldBe` "{aspect-ratio:not valid}"

--- a/spec/Clay/GeometrySpec.hs
+++ b/spec/Clay/GeometrySpec.hs
@@ -49,5 +49,5 @@ spec = do
       evaluate (compactRender $ aspectRatio $ auto `withFallback` auto) `shouldThrow` anyErrorCall
       evaluate (compactRender $ aspectRatio $ (4%3) `withFallback` (4%3)) `shouldThrow` anyErrorCall
 
-    it "has arbtrary other value" $ do
+    it "has arbitrary other value" $ do
       compactRender (aspectRatio $ other "not valid") `shouldBe` "{aspect-ratio:not valid}"

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 module Clay.Geometry
 (
 -- * Positioning.

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Clay.Geometry
 (

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -53,6 +53,16 @@ maxHeight = key "max-height"
 
 -------------------------------------------------------------------------------
 
+-- | Represents an aspect ratio for use with 'aspectRatio'.
+--
+-- A fixed ratio can be formed from two integers:
+--
+-- >>> let _ = 4%3 :: AspectRatio
+--
+-- An aspect ratio can also be converted from a 'Rational':
+--
+-- >>> let _ = fromRational 0.5 :: AspectRatio
+--
 data AspectRatio = AspectRatio Rational
                  | AspectRatioValue Value
                  | AspectRatioWithFallback (AspectRatio, AspectRatio)
@@ -61,7 +71,10 @@ instance Auto AspectRatio where auto = AspectRatioValue auto
 instance Inherit AspectRatio where inherit = AspectRatioValue inherit
 instance Initial AspectRatio where initial = AspectRatioValue initial
 instance Unset AspectRatio where unset = AspectRatioValue unset
+instance Other AspectRatio where other = AspectRatioValue
 
+-- | An 'AspectRatio' can be converted from an 'Integer',
+-- but other operations are not supported.
 instance Num AspectRatio where
   fromInteger = AspectRatio . toRational
   (+)    = error   "plus not implemented for AspectRatio"
@@ -70,6 +83,8 @@ instance Num AspectRatio where
   signum = error "signum not implemented for AspectRatio"
   negate = error "negate not implemented for AspectRatio"
 
+-- | An 'AspectRatio' can be converted from a 'Rational',
+-- but other operations are not supported.
 instance Fractional AspectRatio where
   fromRational = AspectRatio
   recip  = error  "recip not implemented for AspectRatio"
@@ -82,15 +97,54 @@ instance Val AspectRatio where
           denominator = show (R.denominator r)
   value (AspectRatioWithFallback (a, b)) = value a <> " " <> value b
 
+-- | Defines the width to height ratio of an element.
+-- At least one of the width or height must be of automatic size,
+-- otherwise the aspect ratio will be ignored.
+--
+-- It can be given a fixed ratio of the width and to the height:
+--
+-- >>> renderWith compact [] $ aspectRatio (4%3)
+-- "{aspect-ratio:4/3}"
+--
+-- It can also be the intrinsic aspect ratio for the element:
+--
+-- >>> renderWith compact [] $ aspectRatio auto
+-- "{aspect-ratio:auto}"
+--
+-- It can be told to use the intrinsic aspect ratio for the element,
+-- but to use a fixed ratio while it is unknown or does not have one:
+--
+-- >>> renderWith compact [] $ aspectRatio $ auto `withFallback` (4%3)
+-- "{aspect-ratio:auto 4/3}"
+--
+-- Corresponds to the
+-- [@aspect-ratio@](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio)
+-- property in CSS.
 aspectRatio :: AspectRatio -> Css
 aspectRatio = key "aspect-ratio"
 
+-- | The aspect ratio of the width to the height for use with 'aspectRatio'.
+--
+-- Note that this is /not/ the same @%@ operator from the "Data.Ratio" module,
+-- although they do both semantically represent ratios.  The same symbol is used
+-- to signify that the return value is a ratio.
 (%) :: Integer -> Integer -> AspectRatio
 (%) m n = fromRational $ (R.%) m n
 
-infixl 7  %
+-- The same as the normal % operator.
+infixl 7 %
 
+-- | A type class for which a type can have a value with another value as a fallback.
+-- Basically, a type class for types which can use 'withFallback'.
+--
+-- 'withFallback' was defined for 'AspectRatio', but this is a type class
+-- because 'withFallback' is a generic name which we may want to reuse
+-- for other types in the future.
 class WithFallback a where
+  -- | Returns a value where one value has another value as a fallback.
+  --
+  -- * For 'AspectRatio', it can be used to specify that the intrinsic aspect
+  --   ratio should be used, but a fixed ratio can be used as a fallback.
   withFallback :: a -> a -> a
 
 instance WithFallback AspectRatio where
@@ -99,7 +153,7 @@ instance WithFallback AspectRatio where
   withFallback x@(AspectRatio _) y@(AspectRatioValue "auto") =
     AspectRatioWithFallback (x, y)
   withFallback _ _ =
-    error "aspectRatio withFallback must be auto and a ratio in either order"
+    error "Arguments for aspectRatio . withFallback must be auto and a ratio in either order"
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -99,7 +99,7 @@ instance Val AspectRatio where
 -- At least one of the width or height must be of automatic size,
 -- otherwise the aspect ratio will be ignored.
 --
--- It can be given a fixed ratio of the width and to the height:
+-- It can be given a fixed ratio of the width to the height:
 --
 -- >>> renderWith compact [] $ aspectRatio (4%3)
 -- "{aspect-ratio:4/3}"

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -132,26 +132,16 @@ aspectRatio = key "aspect-ratio"
 -- The same as the normal % operator.
 infixl 7 %
 
--- | A type class for which a type can have a value with another value as a fallback.
--- Basically, a type class for types which can use 'withFallback'.
---
--- 'withFallback' was defined for 'AspectRatio', but this is a type class
--- because 'withFallback' is a generic name which we may want to reuse
--- for other types in the future.
-class WithFallback a where
-  -- | Returns a value where one value has another value as a fallback.
-  --
-  -- * For 'AspectRatio', it can be used to specify that the intrinsic aspect
-  --   ratio should be used, but a fixed ratio can be used as a fallback.
-  withFallback :: a -> a -> a
-
-instance WithFallback AspectRatio where
-  withFallback x@(AspectRatioValue "auto") y@(AspectRatio _) =
-    AspectRatioWithFallback (x, y)
-  withFallback x@(AspectRatio _) y@(AspectRatioValue "auto") =
-    AspectRatioWithFallback (x, y)
-  withFallback _ _ =
-    error "Arguments for aspectRatio . withFallback must be auto and a ratio in either order"
+-- | Returns an aspect ratio specifying that the intrinsic aspect
+-- ratio should be used, but when it is unknown or there is none,
+-- a fixed ratio can be used as a fallback.
+withFallback :: AspectRatio -> AspectRatio -> AspectRatio
+withFallback x@(AspectRatioValue "auto") y@(AspectRatio _) =
+  AspectRatioWithFallback (x, y)
+withFallback x@(AspectRatio _) y@(AspectRatioValue "auto") =
+  AspectRatioWithFallback (x, y)
+withFallback _ _ =
+  error "Arguments for aspectRatio . withFallback must be auto and a ratio in either order"
 
 -------------------------------------------------------------------------------
 

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 module Clay.Geometry
 (
 -- * Positioning.
@@ -6,6 +8,12 @@ module Clay.Geometry
 
 -- * Sizing.
 , width, height, minWidth, minHeight, maxWidth, maxHeight
+
+-- ** Aspect ratio.
+, AspectRatio
+, aspectRatio
+, (%)
+, withFallback
 
 -- * Padding.
 , padding
@@ -17,6 +25,9 @@ module Clay.Geometry
 )
 where
 
+import qualified Data.Ratio as R
+import Data.String (fromString)
+import Clay.Common
 import Clay.Property
 import Clay.Stylesheet
 import Clay.Size
@@ -42,6 +53,56 @@ maxHeight = key "max-height"
 
 -------------------------------------------------------------------------------
 
+data AspectRatio = AspectRatio Rational
+                 | AspectRatioValue Value
+                 | AspectRatioWithFallback (AspectRatio, AspectRatio)
+
+instance Auto AspectRatio where auto = AspectRatioValue auto
+instance Inherit AspectRatio where inherit = AspectRatioValue inherit
+instance Initial AspectRatio where initial = AspectRatioValue initial
+instance Unset AspectRatio where unset = AspectRatioValue unset
+
+instance Num AspectRatio where
+  fromInteger = AspectRatio . toRational
+  (+)    = error   "plus not implemented for AspectRatio"
+  (*)    = error  "times not implemented for AspectRatio"
+  abs    = error    "abs not implemented for AspectRatio"
+  signum = error "signum not implemented for AspectRatio"
+  negate = error "negate not implemented for AspectRatio"
+
+instance Fractional AspectRatio where
+  fromRational = AspectRatio
+  recip  = error  "recip not implemented for AspectRatio"
+
+instance Val AspectRatio where
+  value (AspectRatioValue v) = v
+  value (AspectRatio r) = v
+    where v = fromString $ numerator <> "/" <> denominator :: Value
+          numerator = show (R.numerator r)
+          denominator = show (R.denominator r)
+  value (AspectRatioWithFallback (a, b)) = value a <> " " <> value b
+
+aspectRatio :: AspectRatio -> Css
+aspectRatio = key "aspect-ratio"
+
+(%) :: Integer -> Integer -> AspectRatio
+(%) m n = fromRational $ (R.%) m n
+
+infixl 7  %
+
+class WithFallback a where
+  withFallback :: a -> a -> a
+
+instance WithFallback AspectRatio where
+  withFallback x@(AspectRatioValue "auto") y@(AspectRatio _) =
+    AspectRatioWithFallback (x, y)
+  withFallback x@(AspectRatio _) y@(AspectRatioValue "auto") =
+    AspectRatioWithFallback (x, y)
+  withFallback _ _ =
+    error "aspectRatio withFallback must be auto and a ratio in either order"
+
+-------------------------------------------------------------------------------
+
 padding :: Size a -> Size a -> Size a -> Size a -> Css
 padding a b c d = key "padding" (a ! b ! c ! d)
 
@@ -63,4 +124,3 @@ marginTop     = key "margin-top"
 marginLeft    = key "margin-left"
 marginRight   = key "margin-right"
 marginBottom  = key "margin-bottom"
-

--- a/src/Clay/Geometry.hs
+++ b/src/Clay/Geometry.hs
@@ -110,7 +110,7 @@ instance Val AspectRatio where
 -- "{aspect-ratio:auto}"
 --
 -- It can be told to use the intrinsic aspect ratio for the element,
--- but to use a fixed ratio while it is unknown or does not have one:
+-- but to use a fixed ratio while it is unknown or if the element does not have one:
 --
 -- >>> renderWith compact [] $ aspectRatio $ auto `withFallback` (4%3)
 -- "{aspect-ratio:auto 4/3}"


### PR DESCRIPTION
This adds an `aspectRatio` function for generating the `aspect-ratio` CSS property and an `AspectRatio` type to represent aspect ratios.  To make the ratios feel more like [`Data.Ratio`](https://hackage.haskell.org/package/base-4.20.0.1/docs/Data-Ratio.html) ratios, this defines a `%` operator on two `Integer`s generating an `AspectRatio`.  So we could do things like this:

```haskell
aspectRatio (16%9)
aspectRatio auto
```

To allow for properties such as `aspect-ratio: auto 4/3`, we use a `withFallback` function to generate an `AspectRatio`:

```haskell
aspectRatio $ auto `withFallback` (16%9)
```

It is not legal to do something like `aspect-ratio: auto auto`.  While it would have been nice if we could have enforced this with types, this is hard, so it is enforced as a runtime error instead.

The original plan in https://github.com/sebastiaanvisser/clay/issues/259 was based on a type class.  This worked correctly, but not nicely, because types could not be inferred completely.  For example, if we did

```haskell
aspectRatio (16%9)
```

the compiler would not know what type `aspectRatio` should accept yet.  And it can't infer that `16%9` should be `Rational` or `Ratio Int` because it doesn't know whether 16 or 9 are `Integer`s or `Int`s.  We could resolve the deadlock by enabling type defaulting, but lots of code disable it (e.g., when turning on `-Wall -Werror`).  So we would often have to do something like

```haskell
aspectRatio (16%9 :: Rational)
aspectRatio (auto :: Value)
aspectRatio (auto :: Value, 16%9 :: Rational)
```

which seemed cumbersome, so I gave up on the approach based on a type class.

Generated Haddock documentation can be seen in [clay-haddock.tar.gz](https://github.com/user-attachments/files/17447819/clay-haddock.tar.gz).  The examples in the documentation may seem odd, but they're written this way so that they can correctly be evaluated in case [`doctest`](https://hackage.haskell.org/package/doctest) is used one day to test the examples.

Resolves https://github.com/sebastiaanvisser/clay/issues/259.