### PR TITLE
Support `stretch` in `justify-content`.

### DIFF
--- a/spec/Clay/FlexboxSpec.hs
+++ b/spec/Clay/FlexboxSpec.hs
@@ -1,0 +1,44 @@
+{-#LANGUAGE OverloadedStrings#-}
+
+module Clay.FlexboxSpec where
+
+import Clay.Common
+import Clay.Flexbox
+import Clay.Render
+import Clay.Stylesheet
+
+import Test.Hspec
+import Data.Text.Lazy (Text)
+
+compactRender :: Css -> Text
+compactRender = renderWith compact []
+
+spec :: Spec
+spec = do
+  describe "justify-content" $ do
+    it "is inherit" $ do
+      (compactRender $ justifyContent inherit) `shouldBe` "{justify-content:inherit}"
+
+    it "is center" $ do
+      (compactRender $ justifyContent center) `shouldBe` "{justify-content:center}"
+
+    it "is flex-end" $ do
+      (compactRender $ justifyContent flexEnd) `shouldBe` "{justify-content:flex-end}"
+
+    it "is flex-start" $ do
+      (compactRender $ justifyContent flexStart) `shouldBe` "{justify-content:flex-start}"
+
+    it "is space-around" $ do
+      (compactRender $ justifyContent spaceAround) `shouldBe` "{justify-content:space-around}"
+
+    it "is space-between" $ do
+      (compactRender $ justifyContent spaceBetween) `shouldBe` "{justify-content:space-between}"
+
+    it "is space-evenly" $ do
+      (compactRender $ justifyContent spaceEvenly) `shouldBe` "{justify-content:space-evenly}"
+
+    it "is stretch" $ do
+      (compactRender $ justifyContent stretch) `shouldBe` "{justify-content:stretch}"
+
+    it "is other" $ do
+      (compactRender $ justifyContent $ other "random") `shouldBe` "{justify-content:random}"

--- a/src/Clay/Flexbox.hs
+++ b/src/Clay/Flexbox.hs
@@ -109,7 +109,7 @@ flexWrap = key "flex-wrap"
 
 newtype JustifyContentValue = JustifyContentValue Value
   deriving (Val, Other, Inherit, Center, FlexEnd
-          , FlexStart, SpaceAround, SpaceBetween, SpaceEvenly)
+          , FlexStart, SpaceAround, SpaceBetween, SpaceEvenly, Stretch)
 
 justifyContent :: JustifyContentValue -> Css
 justifyContent = key "justify-content"


### PR DESCRIPTION
Also added tests for `justifyContent`.  Resolves https://github.com/sebastiaanvisser/clay/issues/247.